### PR TITLE
feat: Add enum converter

### DIFF
--- a/src/Converters/ClassConverter.php
+++ b/src/Converters/ClassConverter.php
@@ -20,7 +20,7 @@ class ClassConverter implements Converter
     use InteractsWithTypes;
 
     /**
-     * @var ReflectionClass<object>
+     * @var \ReflectionClass<object>
      */
     protected ReflectionClass $reflection;
 

--- a/src/Converters/EnumConverter.php
+++ b/src/Converters/EnumConverter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\JsonSchema\Converters;
+
+use ReflectionEnum;
+use Cortex\JsonSchema\Support\DocParser;
+use Cortex\JsonSchema\Types\ObjectSchema;
+use Cortex\JsonSchema\Types\StringSchema;
+use Cortex\JsonSchema\Contracts\Converter;
+use Cortex\JsonSchema\Types\IntegerSchema;
+use Cortex\JsonSchema\Exceptions\SchemaException;
+
+class EnumConverter implements Converter
+{
+    /**
+     * @var \ReflectionEnum<object>
+     */
+    protected ReflectionEnum $reflection;
+
+    /**
+     * @param class-string<\BackedEnum> $enum
+     */
+    public function __construct(
+        protected string $enum,
+    ) {
+        $this->reflection = new ReflectionEnum($this->enum);
+    }
+
+    public function convert(): ObjectSchema
+    {
+        $schema = new ObjectSchema();
+
+        // Get the description from the doc parser
+        $description = $this->getDocParser($this->reflection)?->description() ?? null;
+
+        // Add the description to the schema if it exists
+        if ($description !== null) {
+            $schema->description($description);
+        }
+
+        // Get the basename of the enum namespace
+        $parts = explode('\\', $this->enum);
+        $enumName = end($parts);
+
+        // Get the possible values of the enum cases
+        $values = array_map(fn($case) => $case->getValue()->value, $this->reflection->getCases());
+
+        // Determine the backing type
+        return match ($this->reflection->getBackingType()?->getName()) {
+            'string' => $schema->properties((new StringSchema($enumName))->enum($values)->required()),
+            'int' => $schema->properties((new IntegerSchema($enumName))->enum($values)->required()),
+            default => throw new SchemaException('Unsupported enum backing type. Only "int" or "string" are supported.'),
+        };
+    }
+
+    /**
+     * @param ReflectionEnum<\BackedEnum> $reflection
+     */
+    protected function getDocParser(ReflectionEnum $reflection): ?DocParser
+    {
+        if ($docComment = $reflection->getDocComment()) {
+            return new DocParser($docComment);
+        }
+
+        return null;
+    }
+}

--- a/src/Converters/EnumConverter.php
+++ b/src/Converters/EnumConverter.php
@@ -6,7 +6,6 @@ namespace Cortex\JsonSchema\Converters;
 
 use BackedEnum;
 use ReflectionEnum;
-use ReflectionEnumBackedCase;
 use Cortex\JsonSchema\Support\DocParser;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Types\StringSchema;

--- a/tests/Unit/Converters/EnumConverterTest.php
+++ b/tests/Unit/Converters/EnumConverterTest.php
@@ -37,12 +37,12 @@ it('can create a schema from an enum', function (): void {
 });
 
 it('throws an exception if the enum is not a backed enum', function (): void {
-    enum UserStatus
+    enum UserStatusNotBacked
     {
         case Active;
         case Inactive;
         case Pending;
     }
 
-    (new EnumConverter(UserStatus::class))->convert();
+    new EnumConverter(UserStatusNotBacked::class);
 })->throws(SchemaException::class);

--- a/tests/Unit/Converters/EnumConverterTest.php
+++ b/tests/Unit/Converters/EnumConverterTest.php
@@ -10,14 +10,14 @@ use Cortex\JsonSchema\Exceptions\SchemaException;
 
 it('can create a schema from an enum', function (): void {
     /** This is the description of the enum */
-    enum UserStatus: string
+    enum PostStatus: string
     {
-        case Active = 'active';
-        case Inactive = 'inactive';
-        case Pending = 'pending';
+        case Draft = 'draft';
+        case Published = 'published';
+        case Archived = 'archived';
     }
 
-    $schema = (new EnumConverter(UserStatus::class))->convert();
+    $schema = (new EnumConverter(PostStatus::class))->convert();
 
     expect($schema)->toBeInstanceOf(ObjectSchema::class);
     expect($schema->toArray())->toBe([
@@ -25,13 +25,13 @@ it('can create a schema from an enum', function (): void {
         '$schema' => 'http://json-schema.org/draft-07/schema#',
         'description' => 'This is the description of the enum',
         'properties' => [
-            'UserStatus' => [
+            'PostStatus' => [
                 'type' => 'string',
-                'enum' => ['active', 'inactive', 'pending'],
+                'enum' => ['draft', 'published', 'archived'],
             ],
         ],
         'required' => [
-            'UserStatus',
+            'PostStatus',
         ],
     ]);
 });

--- a/tests/Unit/Converters/EnumConverterTest.php
+++ b/tests/Unit/Converters/EnumConverterTest.php
@@ -8,8 +8,8 @@ use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Converters\EnumConverter;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
-it('can create a schema from an enum', function (): void {
-    /** This is the description of the enum */
+it('can create a schema from an string backed enum', function (): void {
+    /** This is the description of the string backed enum */
     enum PostStatus: string
     {
         case Draft = 'draft';
@@ -23,7 +23,7 @@ it('can create a schema from an enum', function (): void {
     expect($schema->toArray())->toBe([
         'type' => 'object',
         '$schema' => 'http://json-schema.org/draft-07/schema#',
-        'description' => 'This is the description of the enum',
+        'description' => 'This is the description of the string backed enum',
         'properties' => [
             'PostStatus' => [
                 'type' => 'string',
@@ -32,6 +32,34 @@ it('can create a schema from an enum', function (): void {
         ],
         'required' => [
             'PostStatus',
+        ],
+    ]);
+});
+
+it('can create a schema from an integer backed enum', function (): void {
+    /** This is the description of the integer backed enum */
+    enum PostType: int
+    {
+        case Article = 1;
+        case News = 2;
+        case Tutorial = 3;
+    }
+
+    $schema = (new EnumConverter(PostType::class))->convert();
+
+    expect($schema)->toBeInstanceOf(ObjectSchema::class);
+    expect($schema->toArray())->toBe([
+        'type' => 'object',
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'description' => 'This is the description of the integer backed enum',
+        'properties' => [
+            'PostType' => [
+                'type' => 'integer',
+                'enum' => [1, 2, 3],
+            ],
+        ],
+        'required' => [
+            'PostType',
         ],
     ]);
 });

--- a/tests/Unit/Converters/EnumConverterTest.php
+++ b/tests/Unit/Converters/EnumConverterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\JsonSchema\Tests\Unit\Converters;
+
+use Cortex\JsonSchema\Types\ObjectSchema;
+use Cortex\JsonSchema\Converters\EnumConverter;
+use Cortex\JsonSchema\Exceptions\SchemaException;
+
+it('can create a schema from an enum', function (): void {
+    /** This is the description of the enum */
+    enum UserStatus: string
+    {
+        case Active = 'active';
+        case Inactive = 'inactive';
+        case Pending = 'pending';
+    }
+
+    $schema = (new EnumConverter(UserStatus::class))->convert();
+
+    expect($schema)->toBeInstanceOf(ObjectSchema::class);
+    expect($schema->toArray())->toBe([
+        'type' => 'object',
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'description' => 'This is the description of the enum',
+        'properties' => [
+            'UserStatus' => [
+                'type' => 'string',
+                'enum' => ['active', 'inactive', 'pending'],
+            ],
+        ],
+        'required' => [
+            'UserStatus',
+        ],
+    ]);
+});
+
+it('throws an exception if the enum is not a backed enum', function (): void {
+    enum UserStatus
+    {
+        case Active;
+        case Inactive;
+        case Pending;
+    }
+
+    (new EnumConverter(UserStatus::class))->convert();
+})->throws(SchemaException::class);


### PR DESCRIPTION
This pull request introduces the `EnumConverter` class to the codebase, which provides functionality for converting enums into JSON schemas. Additionally, it includes a minor change to the `ClassConverter` class.

New `EnumConverter` class:

* [`src/Converters/EnumConverter.php`](diffhunk://#diff-5fe742df600d65be9fcbeb4ec460bd1b534df6752bbb74d04d7900edbe7234bfR1-R75): Added the `EnumConverter` class, which converts enums into JSON schemas. It supports enums backed by `int` or `string` types and includes methods for handling enum descriptions and backing types.

Unit tests for `EnumConverter`:

* [`tests/Unit/Converters/EnumConverterTest.php`](diffhunk://#diff-ac8e787b70d8fb16e4b07eaf1b65b764eb9c8aae3241b5730ef2e01f20a43bb4R1-R48): Added unit tests for the `EnumConverter` class to verify its functionality, including tests for creating schemas from enums and handling non-backed enums.

Minor change to `ClassConverter`:

* [`src/Converters/ClassConverter.php`](diffhunk://#diff-4a563f5ab5dc480f21e40c9267fa85959bfca2c1d479eff738a10bdc401ee788L23-R23): Updated the `@var` annotation for the `reflection` property to use the fully qualified class name `\ReflectionClass`.