### PR TITLE
feat: Allow additional properties to accept schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,43 @@ $schema->toJson();
 }
 ```
 
+### From an Backed Enum
+
+```php
+use Cortex\JsonSchema\SchemaFactory;
+
+/**
+ * This is the description of the enum
+ */
+enum PostType: int
+{
+    case Article = 1;
+    case News = 2;
+    case Tutorial = 3;
+}
+
+// Build the schema from the enum
+$schema = SchemaFactory::fromEnum(PostType::class);
+
+// Convert to JSON Schema
+$schema->toJson();
+```
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "description": "This is the description of the enum",
+    "properties": {
+        "PostType": {
+            "type": "integer",
+            "enum": [1, 2, 3]
+        }
+    },
+    "required": ["PostType"]
+}
+```
+
 ## Credits
 
 - [Sean Tymon](https://github.com/tymondesigns)

--- a/README.md
+++ b/README.md
@@ -431,13 +431,43 @@ $schema = SchemaFactory::object('config')
     // Control number of properties
     ->minProperties(1)
     ->maxProperties(10)
-    ->additionalProperties(false);
+    // Control additional properties
+    ->additionalProperties(false); // Disallow additional properties
+
+// Or validate additional properties against a schema
+$schema = SchemaFactory::object('config')
+    ->properties(
+        SchemaFactory::string('name')->required(),
+        SchemaFactory::string('type')->required(),
+    )
+    ->additionalProperties(
+        SchemaFactory::string()->minLength(3)
+    );
 ```
 
 ```php
 // Property names must be alphabetic
 $schema->isValid(['123' => 'value']); // false
 $schema->isValid(['validKey' => 'value']); // true
+
+// Additional properties must match schema
+$schema->isValid([
+    'name' => 'config1',
+    'type' => 'test',
+    'extra' => 'valid', // valid: string with length >= 3
+]); // true
+
+$schema->isValid([
+    'name' => 'config1',
+    'type' => 'test',
+    'extra' => 'no', // invalid: string too short
+]); // false
+
+$schema->isValid([
+    'name' => 'config1',
+    'type' => 'test',
+    'extra' => 123, // invalid: wrong type
+]); // false
 ```
 
 Objects also support pattern-based property validation using `patternProperties`:

--- a/src/Types/Concerns/HasProperties.php
+++ b/src/Types/Concerns/HasProperties.php
@@ -20,7 +20,10 @@ trait HasProperties
      */
     protected array $requiredProperties = [];
 
-    protected ?bool $additionalProperties = null;
+    /**
+     * @var bool|\Cortex\JsonSchema\Contracts\Schema|null
+     */
+    protected mixed $additionalProperties = null;
 
     protected ?int $minProperties = null;
 
@@ -58,9 +61,11 @@ trait HasProperties
     }
 
     /**
-     * Allow or disallow additional properties
+     * Set whether additional properties are allowed and optionally their schema
+     *
+     * @param bool|\Cortex\JsonSchema\Contracts\Schema $allowed Whether additional properties are allowed, or a schema they must match
      */
-    public function additionalProperties(bool $allowed): static
+    public function additionalProperties(bool|Schema $allowed): static
     {
         $this->additionalProperties = $allowed;
 
@@ -188,7 +193,9 @@ trait HasProperties
         }
 
         if ($this->additionalProperties !== null) {
-            $schema['additionalProperties'] = $this->additionalProperties;
+            $schema['additionalProperties'] = $this->additionalProperties instanceof Schema
+                ? $this->additionalProperties->toArray(includeSchemaRef: false, includeTitle: false)
+                : $this->additionalProperties;
         }
 
         if ($this->propertyNames !== null) {


### PR DESCRIPTION
This pull request introduces several changes to enhance the handling of additional properties in JSON schemas and adds new functionality for creating schemas from enums. The most important changes include updates to the `README.md` file to document these new features, modifications to the `HasProperties` trait to support schemas for additional properties, and new tests to ensure the correctness of these features.

Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L434-R470): Added examples and explanations for validating additional properties against a schema and creating schemas from enums. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L434-R470) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R951-R987)

Enhancements to property handling:
* [`src/Types/Concerns/HasProperties.php`](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fL23-R26): Updated the `additionalProperties` property and method to support schemas for additional properties. [[1]](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fL23-R26) [[2]](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fL61-R68) [[3]](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fL191-R198)

Testing improvements:
* [`tests/Unit/Targets/ObjectSchemaTest.php`](diffhunk://#diff-5410356ce69b09ee3a9dbd6f961fabe9877122be77b93a3159b6043617c4dd5dR139-R180): Added tests to verify the behavior of schemas with additional properties, including validation of property types and lengths.