### PR TITLE
ci: Add mutation testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,5 +41,10 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Execute tests
+      - name: Execute tests with mutation
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: vendor/bin/pest --colors=always --mutate --parallel --min=80
+
+      - name: Execute tests
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        run: vendor/bin/pest --colors=always

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          coverage: pcov
 
       - name: Setup problem matchers
         run: |
@@ -42,4 +42,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest --colors=always
+        run: vendor/bin/pest --colors=always --mutate --parallel --min=80

--- a/tests/Unit/Converters/ClassConverterTest.php
+++ b/tests/Unit/Converters/ClassConverterTest.php
@@ -7,6 +7,8 @@ namespace Cortex\JsonSchema\Tests\Unit\Converters;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Converters\ClassConverter;
 
+covers(ClassConverter::class);
+
 it('can create a schema from a class', function (): void {
     $schema = (new ClassConverter(new class () {
         public string $name;

--- a/tests/Unit/Converters/ClosureConverterTest.php
+++ b/tests/Unit/Converters/ClosureConverterTest.php
@@ -8,6 +8,8 @@ use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 use Cortex\JsonSchema\Converters\ClosureConverter;
 
+covers(ClosureConverter::class);
+
 it('can create a schema from a closure', function (): void {
     $closure = function (string $name, array $fooArray, ?int $age = null): void {};
     $schema = (new ClosureConverter($closure))->convert();

--- a/tests/Unit/Converters/EnumConverterTest.php
+++ b/tests/Unit/Converters/EnumConverterTest.php
@@ -8,6 +8,8 @@ use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Converters\EnumConverter;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
+covers(EnumConverter::class);
+
 it('can create a schema from an string backed enum', function (): void {
     /** This is the description of the string backed enum */
     enum PostStatus: string

--- a/tests/Unit/SchemaFactoryTest.php
+++ b/tests/Unit/SchemaFactoryTest.php
@@ -15,6 +15,8 @@ use Cortex\JsonSchema\Types\BooleanSchema;
 use Cortex\JsonSchema\Types\IntegerSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 
+covers(Schema::class);
+
 it('can create different schema types', function (): void {
     // Test array schema creation
     expect(Schema::array('items'))->toBeInstanceOf(ArraySchema::class);
@@ -89,4 +91,36 @@ it('can create a schema from a closure', function (): void {
     ]);
 
     expect($schema->toJson())->toBe(json_encode($schema->toArray()));
+});
+
+it('can create a schema from a class', function (): void {
+    /** This is the description of the class */
+    $class = new class ('John Doe') {
+        public function __construct(
+            public string $name,
+            public int $age = 20,
+            protected ?string $email = null,
+        ) {}
+    };
+
+    $schema = Schema::fromClass($class, publicOnly: true);
+
+    expect($schema)->toBeInstanceOf(ObjectSchema::class);
+    expect($schema->toArray())->toBe([
+        'type' => 'object',
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'description' => 'This is the description of the class',
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+            ],
+            'age' => [
+                'type' => 'integer',
+            ],
+        ],
+        'required' => [
+            'name',
+            'age',
+        ],
+    ]);
 });

--- a/tests/Unit/Support/DocParserTest.php
+++ b/tests/Unit/Support/DocParserTest.php
@@ -8,6 +8,8 @@ use Cortex\JsonSchema\Support\NodeData;
 use Cortex\JsonSchema\Support\DocParser;
 use Cortex\JsonSchema\Support\NodeCollection;
 
+covers(DocParser::class);
+
 it('can parse description', function (): void {
     $docblock = '/** This is a test docblock */';
     $parser = new DocParser($docblock);

--- a/tests/Unit/Targets/ArraySchemaTest.php
+++ b/tests/Unit/Targets/ArraySchemaTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Tests\Unit;
 
+use Cortex\JsonSchema\Types\ArraySchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
+
+covers(ArraySchema::class);
 
 it('can create an array schema', function (): void {
     $schema = Schema::array('tags')

--- a/tests/Unit/Targets/BooleanSchemaTest.php
+++ b/tests/Unit/Targets/BooleanSchemaTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Tests\Unit;
 
+use Cortex\JsonSchema\Types\BooleanSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
+
+covers(BooleanSchema::class);
 
 it('can create a boolean schema', function (): void {
     $schema = Schema::boolean('is_active')

--- a/tests/Unit/Targets/IntegerSchemaTest.php
+++ b/tests/Unit/Targets/IntegerSchemaTest.php
@@ -6,6 +6,9 @@ namespace Cortex\JsonSchema\Tests\Unit;
 
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
+use Cortex\JsonSchema\Types\IntegerSchema;
+
+covers(IntegerSchema::class);
 
 it('can create a basic integer schema', function (): void {
     $schema = Schema::integer('age')

--- a/tests/Unit/Targets/NullSchemaTest.php
+++ b/tests/Unit/Targets/NullSchemaTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Cortex\JsonSchema\Tests\Unit;
 
 use stdClass;
+use Cortex\JsonSchema\Types\NullSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
+
+covers(NullSchema::class);
 
 it('can create a basic null schema', function (): void {
     $schema = Schema::null('deleted_at')

--- a/tests/Unit/Targets/NumberSchemaTest.php
+++ b/tests/Unit/Targets/NumberSchemaTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Tests\Unit;
 
+use Cortex\JsonSchema\Types\NumberSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
+
+covers(NumberSchema::class);
 
 it('can create a basic number schema', function (): void {
     $schema = Schema::number('price')

--- a/tests/Unit/Targets/ObjectSchemaTest.php
+++ b/tests/Unit/Targets/ObjectSchemaTest.php
@@ -10,6 +10,8 @@ use Opis\JsonSchema\Errors\ValidationError;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
+covers(ObjectSchema::class);
+
 it('can create a basic object schema', function (): void {
     $schema = Schema::object('user')
         ->description('User schema')

--- a/tests/Unit/Targets/StringSchemaTest.php
+++ b/tests/Unit/Targets/StringSchemaTest.php
@@ -7,6 +7,9 @@ namespace Cortex\JsonSchema\Tests\Unit;
 use Cortex\JsonSchema\Enums\SchemaFormat;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
+use Cortex\JsonSchema\Types\StringSchema;
+
+covers(StringSchema::class);
 
 it('can create a string schema with length constraints', function (): void {
     $schema = Schema::string('username')

--- a/tests/Unit/Targets/UnionSchemaTest.php
+++ b/tests/Unit/Targets/UnionSchemaTest.php
@@ -9,6 +9,8 @@ use Cortex\JsonSchema\Types\UnionSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
+covers(UnionSchema::class);
+
 it('can create a union schema with multiple types', function (): void {
     $schema = Schema::union([SchemaType::String, SchemaType::Integer], 'id')
         ->description('ID can be either a string or an integer');


### PR DESCRIPTION
This pull request includes several changes to the test suite and the workflow configuration. The most important changes include adding `covers` annotations to the test files and updating the GitHub Actions workflow to include mutation testing.

### Test Suite Enhancements:
* Added `covers` annotations to various test files to specify the class being tested:
  - `tests/Unit/Converters/ClassConverterTest.php`
  - `tests/Unit/Converters/ClosureConverterTest.php`
  - `tests/Unit/Converters/EnumConverterTest.php`
  - `tests/Unit/SchemaFactoryTest.php`
  - `tests/Unit/Support/DocParserTest.php`
  - `tests/Unit/Targets/ArraySchemaTest.php`
  - `tests/Unit/Targets/BooleanSchemaTest.php`
  - `tests/Unit/Targets/IntegerSchemaTest.php`
  - `tests/Unit/Targets/NullSchemaTest.php`
  - `tests/Unit/Targets/NumberSchemaTest.php`
  - `tests/Unit/Targets/ObjectSchemaTest.php`
  - `tests/Unit/Targets/StringSchemaTest.php`
  - `tests/Unit/Targets/UnionSchemaTest.php`

### Workflow Configuration:
* Updated `.github/workflows/run-tests.yml` to enable code coverage using `pcov` instead of `none`.
* Added a new step to execute mutation tests on `ubuntu-latest` OS.