### PR TITLE
refactor: Enum converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,7 @@ $schema->toJson();
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "integer",
+    "title": "PostType",
     "description": "This is the description of the enum",
     "enum": [1, 2, 3]
 }

--- a/README.md
+++ b/README.md
@@ -973,15 +973,9 @@ $schema->toJson();
 ```json
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
+    "type": "integer",
     "description": "This is the description of the enum",
-    "properties": {
-        "PostType": {
-            "type": "integer",
-            "enum": [1, 2, 3]
-        }
-    },
-    "required": ["PostType"]
+    "enum": [1, 2, 3]
 }
 ```
 

--- a/src/Contracts/Converter.php
+++ b/src/Contracts/Converter.php
@@ -7,7 +7,7 @@ namespace Cortex\JsonSchema\Contracts;
 interface Converter
 {
     /**
-     * Convert the value to an object schema.
+     * Convert the value to a schema instance.
      */
     public function convert(): Schema;
 }

--- a/src/Contracts/Converter.php
+++ b/src/Contracts/Converter.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Contracts;
 
-use Cortex\JsonSchema\Types\ObjectSchema;
-
 interface Converter
 {
     /**
      * Convert the value to an object schema.
      */
-    public function convert(): ObjectSchema;
+    public function convert(): Schema;
 }

--- a/src/Converters/EnumConverter.php
+++ b/src/Converters/EnumConverter.php
@@ -7,7 +7,6 @@ namespace Cortex\JsonSchema\Converters;
 use BackedEnum;
 use ReflectionEnum;
 use Cortex\JsonSchema\Support\DocParser;
-use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Types\StringSchema;
 use Cortex\JsonSchema\Contracts\Converter;
 use Cortex\JsonSchema\Types\IntegerSchema;
@@ -34,9 +33,22 @@ class EnumConverter implements Converter
         $this->reflection = new ReflectionEnum($this->enum);
     }
 
-    public function convert(): ObjectSchema
+    public function convert(): StringSchema|IntegerSchema
     {
-        $schema = new ObjectSchema();
+        // Get the basename of the enum namespace
+        $enumName = basename(str_replace('\\', '/', $this->enum));
+
+        // Determine the backing type
+        $schema = match ($this->reflection->getBackingType()?->getName()) {
+            'string' => new StringSchema($enumName),
+            'int' => new IntegerSchema($enumName),
+            default => throw new SchemaException('Unsupported enum backing type. Only "int" or "string" are supported.'),
+        };
+
+        /** @var non-empty-array<int, string|int> $values */
+        $values = array_column($this->enum::cases(), 'value');
+
+        $schema->enum($values);
 
         // Get the description from the doc parser
         $description = $this->getDocParser($this->reflection)?->description() ?? null;
@@ -46,19 +58,7 @@ class EnumConverter implements Converter
             $schema->description($description);
         }
 
-        // Get the basename of the enum namespace
-        $parts = explode('\\', $this->enum);
-        $enumName = end($parts);
-
-        /** @var non-empty-array<int, string|int> $values */
-        $values = array_column($this->enum::cases(), 'value');
-
-        // Determine the backing type
-        return match ($this->reflection->getBackingType()?->getName()) {
-            'string' => $schema->properties((new StringSchema($enumName))->enum($values)->required()),
-            'int' => $schema->properties((new IntegerSchema($enumName))->enum($values)->required()),
-            default => throw new SchemaException('Unsupported enum backing type. Only "int" or "string" are supported.'),
-        };
+        return $schema;
     }
 
     /**

--- a/src/Converters/EnumConverter.php
+++ b/src/Converters/EnumConverter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Converters;
 
-use BackedEnum;
 use ReflectionEnum;
 use Cortex\JsonSchema\Support\DocParser;
 use Cortex\JsonSchema\Types\StringSchema;
@@ -25,12 +24,11 @@ class EnumConverter implements Converter
     public function __construct(
         protected string $enum,
     ) {
-        // @phpstan-ignore function.alreadyNarrowedType
-        if (! is_subclass_of($this->enum, BackedEnum::class)) {
+        $this->reflection = new ReflectionEnum($this->enum);
+
+        if (! $this->reflection->isBacked()) {
             throw new SchemaException('Enum must be a backed enum');
         }
-
-        $this->reflection = new ReflectionEnum($this->enum);
     }
 
     public function convert(): StringSchema|IntegerSchema

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Cortex\JsonSchema\Tests;
 
 use Throwable;
+use Cortex\JsonSchema\Contracts\Schema;
+use Cortex\JsonSchema\Contracts\Converter;
 
 arch()->preset()->php();
 arch()->preset()->security();
 
 arch()->expect('Cortex\JsonSchema\Contracts')->toBeInterfaces();
 arch()->expect('Cortex\JsonSchema\Enums')->toBeEnums();
-arch()->expect('Cortex\JsonSchema\Exceptions')->toExtend(Throwable::class);
+arch()->expect('Cortex\JsonSchema\Exceptions')->toImplement(Throwable::class);
+arch()->expect('Cortex\JsonSchema\Converters')->classes()->toImplement(Converter::class);
+arch()->expect('Cortex\JsonSchema\Types')->classes()->toImplement(Schema::class);

--- a/tests/Unit/Converters/EnumConverterTest.php
+++ b/tests/Unit/Converters/EnumConverterTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Tests\Unit\Converters;
 
-use Cortex\JsonSchema\Types\ObjectSchema;
+use Cortex\JsonSchema\Types\StringSchema;
+use Cortex\JsonSchema\Types\IntegerSchema;
 use Cortex\JsonSchema\Converters\EnumConverter;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
@@ -21,20 +22,13 @@ it('can create a schema from an string backed enum', function (): void {
 
     $schema = (new EnumConverter(PostStatus::class))->convert();
 
-    expect($schema)->toBeInstanceOf(ObjectSchema::class);
+    expect($schema)->toBeInstanceOf(StringSchema::class);
     expect($schema->toArray())->toBe([
-        'type' => 'object',
+        'type' => 'string',
         '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'title' => 'PostStatus',
         'description' => 'This is the description of the string backed enum',
-        'properties' => [
-            'PostStatus' => [
-                'type' => 'string',
-                'enum' => ['draft', 'published', 'archived'],
-            ],
-        ],
-        'required' => [
-            'PostStatus',
-        ],
+        'enum' => ['draft', 'published', 'archived'],
     ]);
 });
 
@@ -49,20 +43,13 @@ it('can create a schema from an integer backed enum', function (): void {
 
     $schema = (new EnumConverter(PostType::class))->convert();
 
-    expect($schema)->toBeInstanceOf(ObjectSchema::class);
+    expect($schema)->toBeInstanceOf(IntegerSchema::class);
     expect($schema->toArray())->toBe([
-        'type' => 'object',
+        'type' => 'integer',
         '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'title' => 'PostType',
         'description' => 'This is the description of the integer backed enum',
-        'properties' => [
-            'PostType' => [
-                'type' => 'integer',
-                'enum' => [1, 2, 3],
-            ],
-        ],
-        'required' => [
-            'PostType',
-        ],
+        'enum' => [1, 2, 3],
     ]);
 });
 

--- a/tests/Unit/SchemaFactoryTest.php
+++ b/tests/Unit/SchemaFactoryTest.php
@@ -91,6 +91,9 @@ it('can create a schema from a closure', function (): void {
     ]);
 
     expect($schema->toJson())->toBe(json_encode($schema->toArray()));
+
+    // Assert that the from method behaves in the same way as the fromClosure method
+    expect(Schema::from($closure))->toEqual($schema);
 });
 
 it('can create a schema from a class', function (): void {
@@ -123,4 +126,32 @@ it('can create a schema from a class', function (): void {
             'age',
         ],
     ]);
+
+    // Assert that the from method behaves in the same way as the fromClass method
+    expect(Schema::from($class))->toEqual($schema);
+});
+
+it('can create a schema from an enum', function (): void {
+    /** This is a custom enum for testing */
+    enum UserRole: string
+    {
+        case Admin = 'admin';
+        case Editor = 'editor';
+        case Viewer = 'viewer';
+        case Guest = 'guest';
+    }
+
+    $schema = Schema::fromEnum(UserRole::class);
+
+    expect($schema)->toBeInstanceOf(StringSchema::class);
+    expect($schema->toArray())->toBe([
+        'type' => 'string',
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'title' => 'UserRole',
+        'description' => 'This is a custom enum for testing',
+        'enum' => ['admin', 'editor', 'viewer', 'guest'],
+    ]);
+
+    // Assert that the from method behaves in the same way as the fromEnum method
+    expect(Schema::from(UserRole::class))->toEqual($schema);
 });

--- a/tests/Unit/Targets/IntegerSchemaTest.php
+++ b/tests/Unit/Targets/IntegerSchemaTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Tests\Unit;
 
+use Cortex\JsonSchema\Types\IntegerSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
-use Cortex\JsonSchema\Types\IntegerSchema;
 
 covers(IntegerSchema::class);
 

--- a/tests/Unit/Targets/StringSchemaTest.php
+++ b/tests/Unit/Targets/StringSchemaTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Cortex\JsonSchema\Tests\Unit;
 
 use Cortex\JsonSchema\Enums\SchemaFormat;
+use Cortex\JsonSchema\Types\StringSchema;
 use Cortex\JsonSchema\SchemaFactory as Schema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
-use Cortex\JsonSchema\Types\StringSchema;
 
 covers(StringSchema::class);
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of enums in the `Cortex\JsonSchema` library. The most important changes involve updating the `EnumConverter` and `SchemaFactory` classes, as well as modifying related tests to reflect these updates.

### Enum Handling Improvements:

* [`src/Contracts/Converter.php`](diffhunk://#diff-d3a10846c1b9e80cca4c307c228d69b31b7f65f0ee06c0aa770d9e71caf6995dL7-R12): Updated the `convert` method to return a `Schema` instance instead of an `ObjectSchema`.
* [`src/Converters/EnumConverter.php`](diffhunk://#diff-5fe742df600d65be9fcbeb4ec460bd1b534df6752bbb74d04d7900edbe7234bfL29-R49): Modified the `EnumConverter` class to support both `StringSchema` and `IntegerSchema` based on the enum's backing type. [[1]](diffhunk://#diff-5fe742df600d65be9fcbeb4ec460bd1b534df6752bbb74d04d7900edbe7234bfL29-R49) [[2]](diffhunk://#diff-5fe742df600d65be9fcbeb4ec460bd1b534df6752bbb74d04d7900edbe7234bfL49-R59)
* [`src/SchemaFactory.php`](diffhunk://#diff-01c9a597ec53d234d03e2aa66b76a79d5c40b2cda97003e525c941a4b9141e90L94-R113): Updated the `fromEnum` method to return either a `StringSchema` or `IntegerSchema`, and added a new `from` method to create schemas from various types of values. [[1]](diffhunk://#diff-01c9a597ec53d234d03e2aa66b76a79d5c40b2cda97003e525c941a4b9141e90L94-R113) [[2]](diffhunk://#diff-01c9a597ec53d234d03e2aa66b76a79d5c40b2cda97003e525c941a4b9141e90R21)

### Test Updates:

* [`tests/Unit/Converters/EnumConverterTest.php`](diffhunk://#diff-ac8e787b70d8fb16e4b07eaf1b65b764eb9c8aae3241b5730ef2e01f20a43bb4L24-L37): Updated tests to reflect changes in enum handling, ensuring that `EnumConverter` returns the correct schema type. [[1]](diffhunk://#diff-ac8e787b70d8fb16e4b07eaf1b65b764eb9c8aae3241b5730ef2e01f20a43bb4L24-L37) [[2]](diffhunk://#diff-ac8e787b70d8fb16e4b07eaf1b65b764eb9c8aae3241b5730ef2e01f20a43bb4L52-L65)
* [`tests/Unit/SchemaFactoryTest.php`](diffhunk://#diff-dcd3e94b9645d93a0fd9336fc86afd43f30bbe890faf601ee70215d80c61c380R129-R156): Added tests for the new `from` method in `SchemaFactory` and verified consistency with existing methods.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L976-L985): Updated the JSON schema example to reflect the new structure for enums.