### PR TITLE
chore(deps): Upgrade pest and test php 8.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.4]
+        php: [8.3, 8.4, 8.5]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     "require": {
         "php": "^8.3",
         "opis/json-schema": "^2.4",
-        "phpstan/phpdoc-parser": "^2.0"
+        "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {
-        "pestphp/pest": "^4.0",
-        "pestphp/pest-plugin-type-coverage": "^4.0",
-        "phpstan/phpstan": "^2.0",
+        "pestphp/pest": "^4.1.4",
+        "pestphp/pest-plugin-type-coverage": "^4.0.3",
+        "phpstan/phpstan": "^2.1.32",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.2",
         "symplify/easy-coding-standard": "^13.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "phpstan/phpdoc-parser": "^2.0"
     },
     "require-dev": {
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-type-coverage": "^3.2",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "rector/rector": "^2.0",


### PR DESCRIPTION
This pull request updates the PHP version matrix for CI testing and bumps several dependencies in `composer.json` to their latest versions, ensuring compatibility with newer PHP releases and improving development tooling.

**Testing and compatibility improvements:**

* Added PHP 8.5 to the GitHub Actions test matrix in `.github/workflows/run-tests.yml` to ensure the project is tested against the latest PHP version.

**Dependency updates:**

* Updated `phpstan/phpdoc-parser` requirement to `^2.3` and several dev dependencies (`pestphp/pest`, `pestphp/pest-plugin-type-coverage`, `phpstan/phpstan`, `rector/rector`) to their latest versions in `composer.json` for improved tooling and compatibility.