### PR TITLE
ci: Improve GH workflows

### DIFF
--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -40,7 +40,7 @@ runs:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ inputs.stability }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-composer-
+          ${{ runner.os }}-composer-${{ inputs.stability }}-
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Composer stability preference (prefer-stable, prefer-lowest)'
     required: false
     default: 'prefer-stable'
+  extensions:
+    description: 'PHP extensions to install'
+    required: false
+    default: 'dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo'
 
 runs:
   using: 'composite'
@@ -23,6 +27,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         coverage: ${{ inputs.coverage }}
+        extensions: ${{ inputs.extensions }}
 
     - name: Get Composer Cache Directory
       id: composer-cache

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -1,0 +1,48 @@
+name: 'Setup PHP and Composer'
+description: 'Setup PHP and install Composer dependencies with caching'
+
+inputs:
+  php-version:
+    description: 'PHP version to use'
+    required: false
+    default: '8.3'
+  coverage:
+    description: 'Coverage driver to use (none, xdebug, pcov)'
+    required: false
+    default: 'none'
+  stability:
+    description: 'Composer stability preference (prefer-stable, prefer-lowest)'
+    required: false
+    default: 'prefer-stable'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        coverage: ${{ inputs.coverage }}
+
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ inputs.stability }}-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        if [ "${{ inputs.stability }}" = "prefer-lowest" ]; then
+          composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
+        else
+          composer install --prefer-dist --no-interaction --no-progress
+        fi
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - "dependencies"
       - "composer"
-    versioning-strategy: "widen"
+    versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,22 +24,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Setup PHP and Composer
+        uses: ./.github/actions/setup-php-composer
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: pcov
+          stability: ${{ matrix.stability }}
 
       - name: Setup problem matchers
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests with mutation
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,31 +16,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Setup PHP and Composer
+        uses: ./.github/actions/setup-php-composer
 
       - name: Cache phpstan results
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .phpstan-cache
           key: "result-cache-${{ github.run_id }}" # always write a new cache
@@ -54,28 +36,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Setup PHP and Composer
+        uses: ./.github/actions/setup-php-composer
 
       - name: Check type coverage
         run: vendor/bin/pest --type-coverage --min=100
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP and Composer
+        uses: ./.github/actions/setup-php-composer
+
+      - name: Cache rector results
+        uses: actions/cache@v5
+        with:
+          path: /tmp/rector
+          key: "rector-cache-${{ github.run_id }}" # always write a new cache
+          restore-keys: |
+            rector-cache-
+
+      - name: Cache ecs results
+        uses: actions/cache@v5
+        with:
+          path: /tmp/ecs
+          key: "ecs-cache-${{ github.run_id }}" # always write a new cache
+          restore-keys: |
+            ecs-cache-
+
+      - name: Run format checks
+        run: composer format --no-progress-bar

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ This package supports multiple JSON Schema specification versions with automatic
 
 ### Supported Versions
 
-- **Draft-07** (2018) - Default version for maximum compatibility
+- **Draft 2020-12** - (Default) Latest version with `prefixItems`, dynamic references, and format vocabularies
 - **Draft 2019-09** - Adds advanced features like `$defs`, `unevaluatedProperties`, `deprecated`
-- **Draft 2020-12** - Latest version with `prefixItems`, dynamic references, and format vocabularies
+- **Draft-07** (2018) - Legacy version for maximum compatibility
 
 ## Requirements
 


### PR DESCRIPTION
This pull request introduces a reusable composite GitHub Action for setting up PHP and Composer with dependency caching, and refactors the CI workflows to use this new action. Additionally, it updates the Composer dependency versioning strategy and clarifies the default supported JSON Schema version in the documentation.

**CI/CD Workflow Improvements:**

* Added a new composite action at `.github/actions/setup-php-composer` to standardize PHP setup, Composer installation, and dependency caching with configurable inputs for PHP version, coverage, stability, and extensions.
* Refactored both `run-tests.yml` and `static-analysis.yml` workflows to use the new composite action, removing duplicated setup and install steps and ensuring consistent environment setup across jobs. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L29-L43) [[2]](diffhunk://#diff-e9db86b6fd5f791eb849075b600b921e5e95b978e41f9d290c01027440076ec3L21-R22) [[3]](diffhunk://#diff-e9db86b6fd5f791eb849075b600b921e5e95b978e41f9d290c01027440076ec3L59-R73)

**Dependency Management:**

* Changed Dependabot's Composer versioning strategy from "widen" to "increase-if-necessary" for more controlled updates.

**Documentation:**

* Updated the `README.md` to clarify that Draft 2020-12 is now the default supported JSON Schema version, with Draft-07 as the legacy option.