### PR TITLE
fix: Ensure object properties can have a different title

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -70,4 +70,4 @@ jobs:
             ecs-cache-
 
       - name: Run format checks
-        run: composer format --no-progress-bar
+        run: composer format:check --no-progress-bar

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,18 @@
     "scripts": {
         "test": "pest",
         "ecs": "ecs check --fix",
+        "ecs:check": "ecs check",
         "rector": "rector process",
+        "rector:check": "rector process --dry-run",
         "stan": "phpstan analyse",
         "type-coverage": "pest --type-coverage --min=100",
         "format": [
             "@rector",
             "@ecs"
+        ],
+        "format:check": [
+            "@rector:check",
+            "@ecs:check"
         ],
         "check": [
             "@format",

--- a/docs/json-schema/schema-types/object.mdx
+++ b/docs/json-schema/schema-types/object.mdx
@@ -103,6 +103,29 @@ $productSchema = Schema::object('product')
 ```
 </Accordion>
 
+## Property Titles
+
+Property names are defined by the schema constructor argument, while `title()` is metadata and only included when it differs from the property name:
+
+```php
+$schema = Schema::object()
+    ->properties(
+        Schema::string('email')->title('Email Address')
+    );
+```
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "email": {
+            "type": "string",
+            "title": "Email Address"
+        }
+    }
+}
+```
+
 ## Required Properties
 
 Specify which properties are mandatory:

--- a/src/Contracts/JsonSchema.php
+++ b/src/Contracts/JsonSchema.php
@@ -98,4 +98,9 @@ interface JsonSchema
      * Get the JSON Schema version for this schema.
      */
     public function getVersion(): SchemaVersion;
+
+    /**
+     * Get the initial title.
+     */
+    public function getInitialTitle(): ?string;
 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -174,7 +174,7 @@ class Schema
             // @phpstan-ignore argument.type
             is_array($value) || (is_string($value) && json_validate($value)) => self::fromJson($value, $schemaVersion),
             default => throw new SchemaException(
-                'Unsupported value type. Only closures, enums, and classes are supported.',
+                'Unsupported value type. Only closures, enums, arrays and classes are supported.',
             ),
         };
     }

--- a/src/Types/AbstractSchema.php
+++ b/src/Types/AbstractSchema.php
@@ -19,6 +19,7 @@ use Cortex\JsonSchema\Types\Concerns\HasValidation;
 use Cortex\JsonSchema\Types\Concerns\HasDefinitions;
 use Cortex\JsonSchema\Types\Concerns\HasDescription;
 use Cortex\JsonSchema\Types\Concerns\HasConditionals;
+use Cortex\JsonSchema\Types\Concerns\HasInitialTitle;
 use Cortex\JsonSchema\Types\Concerns\ValidatesVersionFeatures;
 
 abstract class AbstractSchema implements JsonSchema
@@ -33,8 +34,9 @@ abstract class AbstractSchema implements JsonSchema
     use HasReadWrite;
     use HasValidation;
     use HasDescription;
-    use HasConditionals;
     use HasDefinitions;
+    use HasConditionals;
+    use HasInitialTitle;
     use ValidatesVersionFeatures;
 
     protected SchemaVersion $schemaVersion = SchemaVersion::Draft_2020_12;
@@ -47,6 +49,7 @@ abstract class AbstractSchema implements JsonSchema
         ?string $title = null,
         ?SchemaVersion $schemaVersion = null,
     ) {
+        $this->initialTitle = $title;
         $this->title = $title;
         $this->schemaVersion = $schemaVersion ?? SchemaVersion::default();
     }

--- a/src/Types/Concerns/HasInitialTitle.php
+++ b/src/Types/Concerns/HasInitialTitle.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\JsonSchema\Types\Concerns;
+
+/** @mixin \Cortex\JsonSchema\Contracts\JsonSchema */
+trait HasInitialTitle
+{
+    protected ?string $initialTitle = null;
+
+    /**
+     * Get the initial title.
+     *
+     * @internal
+     */
+    public function getInitialTitle(): ?string
+    {
+        return $this->initialTitle;
+    }
+}

--- a/src/Types/Concerns/HasProperties.php
+++ b/src/Types/Concerns/HasProperties.php
@@ -253,8 +253,12 @@ trait HasProperties
      */
     public function requireAll(): static
     {
-        foreach ($this->properties as $name => $property) {
-            $this->requiredProperties[] = $name;
+        foreach ($this->properties as $property) {
+            $title = $this->resolvePropertyTitle($property);
+
+            if ($title !== null) {
+                $this->requiredProperties[] = $title;
+            }
         }
 
         return $this;

--- a/src/Types/Concerns/HasProperties.php
+++ b/src/Types/Concerns/HasProperties.php
@@ -342,9 +342,9 @@ trait HasProperties
     /**
      * Resolve the property title from a schema instance.
      */
-    protected function resolvePropertyTitle(JsonSchema $property): ?string
+    protected function resolvePropertyTitle(JsonSchema $jsonSchema): ?string
     {
-        return $property->getInitialTitle() ?? $property->getTitle();
+        return $jsonSchema->getInitialTitle() ?? $jsonSchema->getTitle();
     }
 
     /**

--- a/tests/Unit/Types/ObjectSchemaTest.php
+++ b/tests/Unit/Types/ObjectSchemaTest.php
@@ -113,7 +113,7 @@ it('can get the underlying errors', function (): void {
     }
 })->throws(SchemaException::class);
 
-it('can set set the property title separately from the property key', function (): void {
+it('can set the property title separately from the property key', function (): void {
     $objectSchema = Schema::object()
         ->properties(
             Schema::string('foo')->title('Foo'),

--- a/tests/Unit/Types/ObjectSchemaTest.php
+++ b/tests/Unit/Types/ObjectSchemaTest.php
@@ -113,6 +113,21 @@ it('can get the underlying errors', function (): void {
     }
 })->throws(SchemaException::class);
 
+it('can set set the property title separately from the property key', function (): void {
+    $objectSchema = Schema::object()
+        ->properties(
+            Schema::string('foo')->title('Foo'),
+            Schema::string('bar'),
+        );
+
+    $schemaArray = $objectSchema->toArray();
+
+    expect($schemaArray)->toHaveKey('properties.foo.type', 'string');
+    expect($schemaArray)->toHaveKey('properties.foo.title', 'Foo');
+    expect($schemaArray)->toHaveKey('properties.bar.type', 'string');
+    expect($schemaArray['properties']['bar'])->not->toHaveKey('title');
+});
+
 it('can create an object schema with additional properties control', function (): void {
     $objectSchema = Schema::object('config')
         ->description('Configuration object')


### PR DESCRIPTION
This pull request introduces support for distinguishing between a property's initial title and its current title in JSON schema definitions. It does so by adding a new `getInitialTitle` method, a supporting trait, and updating how property titles are handled—especially when generating schema arrays. This enables more precise control over property titles, particularly when the property key and title should differ.

Example:
```php
$schema = Schema::object()
    ->properties(
         Schema::string('first_name')->title('First Name'),
         Schema::string('last_name')->title('Last Name'),
    );
```
will produce
```json
{
    "type": "object",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "properties": {
        "first_name": {
            "type": "string",
            "title": "First Name"
        },
        "last_name": {
            "type": "string",
            "title": "Last Name"
        }
    }
}
```

**New feature: Initial property titles**

* Added a new `getInitialTitle` method to the `JsonSchema` contract and implemented it via a new `HasInitialTitle` trait, allowing schemas to track both the original and current title of a property. (`src/Contracts/JsonSchema.php`, `src/Types/Concerns/HasInitialTitle.php`, `src/Types/AbstractSchema.php`) [[1]](diffhunk://#diff-0c13ad7330b91271935acfdc41ad24ad890157f5dc1fca802bf5f556e79c0ab0R101-R105) [[2]](diffhunk://#diff-155737ac675219bbb1e6cae55531b8a147be24aed9540570caad4e252b66f6ebR1-R21) [[3]](diffhunk://#diff-ef2433d25fe3c590d57c9be6b8b576a16554f2db5624467c3971056c5d74fae2R22) [[4]](diffhunk://#diff-ef2433d25fe3c590d57c9be6b8b576a16554f2db5624467c3971056c5d74fae2L36-R39) [[5]](diffhunk://#diff-ef2433d25fe3c590d57c9be6b8b576a16554f2db5624467c3971056c5d74fae2R52)

**Property handling improvements**

* Updated property handling in the `HasProperties` trait to use the new `resolvePropertyTitle` method, which prefers the initial title if present, and to avoid including redundant `title` fields in the generated schema arrays. (`src/Types/Concerns/HasProperties.php`) [[1]](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fL58-R58) [[2]](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fL280-R284) [[3]](diffhunk://#diff-229c1cd1e939c30c268b9c872c142d91420ce2747d18bb2ff7712d3ce831b32fR338-R345)
* Changed the `requireAll` method to use property keys as required property names, ensuring correct mapping regardless of title changes. (`src/Types/Concerns/HasProperties.php`)

**Testing**

* Added a unit test to verify that property titles can be set independently from property keys, and that schema output reflects this distinction. (`tests/Unit/Types/ObjectSchemaTest.php`)