### PR TITLE
feat: Draft-06 support, adding $id and string content annotations

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   notify-docs-repo:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: peter-evans/repository-dispatch@v3
         with:

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,17 @@
+name: Sync Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  notify-docs-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_TOKEN }}
+          repository: cortexphp/docs
+          event-type: docs-updated

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - 🏗️ **Fluent Builder API** - Build JSON Schemas using an intuitive fluent interface
-- 📝 **Multi-Version Support** - Support for JSON Schema Draft-07, Draft 2019-09, and Draft 2020-12
+- 📝 **Multi-Version Support** - Support for JSON Schema Draft-06, Draft-07, Draft 2019-09, and Draft 2020-12
 - ✅ **Validation** - Validate data against schemas with detailed error messages
 - 🤝 **Conditional Schemas** - Support for if/then/else, allOf, anyOf, and not conditions
 - 🔄 **Reflection** - Generate schemas from PHP Classes, Enums and Closures
@@ -24,7 +24,8 @@ This package supports multiple JSON Schema specification versions with automatic
 
 - **Draft 2020-12** - (Default) Latest version with `prefixItems`, dynamic references, and format vocabularies
 - **Draft 2019-09** - Adds advanced features like `$defs`, `unevaluatedProperties`, `deprecated`
-- **Draft-07** (2018) - Legacy version for maximum compatibility
+- **Draft-07** (2018) - Legacy version with broad tool compatibility
+- **Draft-06** (2017) - Legacy version for maximum compatibility with older tooling
 
 ## Requirements
 

--- a/docs/json-schema/advanced/string-formats.mdx
+++ b/docs/json-schema/advanced/string-formats.mdx
@@ -173,27 +173,27 @@ $userProfileSchema->isValid($validProfile); // true
 
 ## Format Support by Version
 
-| Format | Draft-07 | Draft 2019-09 | Draft 2020-12 | Description |
-|--------|----------|---------------|---------------|-------------|
-| `Email` | ✅ | ✅ | ✅ | Standard email address |
-| `Uri` | ✅ | ✅ | ✅ | URI reference |
-| `UriReference` | ✅ | ✅ | ✅ | URI reference (relative or absolute) |
-| `Hostname` | ✅ | ✅ | ✅ | Internet hostname |
-| `Ipv4` | ✅ | ✅ | ✅ | IPv4 address |
-| `Ipv6` | ✅ | ✅ | ✅ | IPv6 address |
-| `Date` | ✅ | ✅ | ✅ | Full date |
-| `Time` | ✅ | ✅ | ✅ | Time |
-| `DateTime` | ✅ | ✅ | ✅ | Date and time |
-| `JsonPointer` | ✅ | ✅ | ✅ | JSON Pointer |
-| `RelativeJsonPointer` | ✅ | ✅ | ✅ | Relative JSON Pointer |
-| `UriTemplate` | ✅ | ✅ | ✅ | URI Template |
-| `Regex` | ✅ | ✅ | ✅ | Regular expression pattern |
+| Format | Draft-06 | Draft-07 | Draft 2019-09 | Draft 2020-12 | Description |
+|--------|----------|----------|---------------|---------------|-------------|
+| `Email` | ✅ | ✅ | ✅ | ✅ | Standard email address |
+| `Uri` | ✅ | ✅ | ✅ | ✅ | URI reference |
+| `UriReference` | ✅ | ✅ | ✅ | ✅ | URI reference (relative or absolute) |
+| `Hostname` | ✅ | ✅ | ✅ | ✅ | Internet hostname |
+| `Ipv4` | ✅ | ✅ | ✅ | ✅ | IPv4 address |
+| `Ipv6` | ✅ | ✅ | ✅ | ✅ | IPv6 address |
+| `Date` | ❌ | ✅ | ✅ | ✅ | Full date |
+| `Time` | ❌ | ✅ | ✅ | ✅ | Time |
+| `DateTime` | ✅ | ✅ | ✅ | ✅ | Date and time |
+| `JsonPointer` | ✅ | ✅ | ✅ | ✅ | JSON Pointer |
+| `RelativeJsonPointer` | ❌ | ✅ | ✅ | ✅ | Relative JSON Pointer |
+| `UriTemplate` | ✅ | ✅ | ✅ | ✅ | URI Template |
+| `Regex` | ❌ | ✅ | ✅ | ✅ | Regular expression pattern |
+| `IdnEmail` | ❌ | ✅ | ✅ | ✅ | Internationalized email |
+| `Iri` | ❌ | ✅ | ✅ | ✅ | Internationalized URI |
+| `IriReference` | ❌ | ✅ | ✅ | ✅ | IRI reference |
 | **Draft 2019-09+** |
-| `Duration` | ❌ | ✅ | ✅ | ISO 8601 duration |
-| `Uuid` | ❌ | ✅ | ✅ | UUID string |
-| `IdnEmail` | ❌ | ✅ | ✅ | Internationalized email |
-| `Iri` | ❌ | ✅ | ✅ | Internationalized URI |
-| `IriReference` | ❌ | ✅ | ✅ | IRI reference |
+| `Duration` | ❌ | ❌ | ✅ | ✅ | ISO 8601 duration |
+| `Uuid` | ❌ | ❌ | ✅ | ✅ | UUID string |
 
 ## Common Use Cases
 

--- a/docs/json-schema/advanced/string-formats.mdx
+++ b/docs/json-schema/advanced/string-formats.mdx
@@ -189,6 +189,7 @@ $userProfileSchema->isValid($validProfile); // true
 | `UriTemplate` | ✅ | ✅ | ✅ | ✅ | URI Template |
 | `Regex` | ❌ | ✅ | ✅ | ✅ | Regular expression pattern |
 | `IdnEmail` | ❌ | ✅ | ✅ | ✅ | Internationalized email |
+| `IdnHostname` | ❌ | ✅ | ✅ | ✅ | Internationalized hostname |
 | `Iri` | ❌ | ✅ | ✅ | ✅ | Internationalized URI |
 | `IriReference` | ❌ | ✅ | ✅ | ✅ | IRI reference |
 | **Draft 2019-09+** |

--- a/docs/json-schema/installation.mdx
+++ b/docs/json-schema/installation.mdx
@@ -26,7 +26,7 @@ icon: 'terminal'
   use Cortex\JsonSchema\Enums\SchemaVersion;
 
   // Override default version (if needed)
-  Schema::setDefaultVersion(SchemaVersion::Draft_07); // For maximum compatibility
+  Schema::setDefaultVersion(SchemaVersion::Draft_06); // For maximum compatibility
   // or
   Schema::setDefaultVersion(SchemaVersion::Draft_2019_09); // For balanced features
   ```

--- a/docs/json-schema/introduction.mdx
+++ b/docs/json-schema/introduction.mdx
@@ -23,7 +23,7 @@ icon: 'book-open'
     href="/json-schema/versions"
     icon="layers"
   >
-    Support for JSON Schema Draft-07, Draft 2019-09, and Draft 2020-12 with automatic feature validation.
+    Support for JSON Schema Draft-06, Draft-07, Draft 2019-09, and Draft 2020-12 with automatic feature validation.
   </Card>
   <Card
     title="Data Validation"
@@ -157,17 +157,17 @@ The package automatically validates feature compatibility with your chosen JSON 
 </Warning>
 
 <Tip>
-The package defaults to Draft 2020-12 for the latest features. Use Draft-07 for maximum compatibility with older tools, or Draft 2019-09 for a balance of features and compatibility.
+The package defaults to Draft 2020-12 for the latest features. Use Draft-06 for maximum compatibility with older tools, or Draft 2019-09 for a balance of features and compatibility.
 </Tip>
 
-| Feature | Draft-07 | Draft 2019-09 | Draft 2020-12 |
-|---------|----------|---------------|---------------|
-| Basic validation | ✅ | ✅ | ✅ |
-| Conditionals | ✅ | ✅ | ✅ |
-| Basic formats | ✅ | ✅ | ✅ |
-| `deprecated` | ❌ | ✅ | ✅ |
-| `$defs` | ❌ | ✅ | ✅ |
-| `minContains`/`maxContains` | ❌ | ✅ | ✅ |
-| `unevaluatedProperties` | ❌ | ✅ | ✅ |
-| `dependentSchemas` | ❌ | ✅ | ✅ |
-| `prefixItems` | ❌ | ❌ | ✅ |
+| Feature | Draft-06 | Draft-07 | Draft 2019-09 | Draft 2020-12 |
+|---------|----------|----------|---------------|---------------|
+| Basic validation | ✅ | ✅ | ✅ | ✅ |
+| Conditionals | ❌ | ✅ | ✅ | ✅ |
+| Basic formats | ✅ | ✅ | ✅ | ✅ |
+| `deprecated` | ❌ | ❌ | ✅ | ✅ |
+| `$defs` | ❌ | ❌ | ✅ | ✅ |
+| `minContains`/`maxContains` | ❌ | ❌ | ✅ | ✅ |
+| `unevaluatedProperties` | ❌ | ❌ | ✅ | ✅ |
+| `dependentSchemas` | ❌ | ❌ | ✅ | ✅ |
+| `prefixItems` | ❌ | ❌ | ❌ | ✅ |

--- a/docs/json-schema/quickstart.mdx
+++ b/docs/json-schema/quickstart.mdx
@@ -258,7 +258,7 @@ $modernSchema = Schema::string('field')
     ->comment('Use newField instead');
 
 // Override default version if needed
-Schema::setDefaultVersion(SchemaVersion::Draft_07); // For maximum compatibility
+Schema::setDefaultVersion(SchemaVersion::Draft_06); // For maximum compatibility
 ```
 
 ## Common Validation Patterns
@@ -322,7 +322,7 @@ Schema::setDefaultVersion(SchemaVersion::Draft_07); // For maximum compatibility
       ->comment('Use new_field instead');
 
   // Override default version if needed for compatibility
-  Schema::setDefaultVersion(SchemaVersion::Draft_07);
+  Schema::setDefaultVersion(SchemaVersion::Draft_06);
   ```
 
   <Warning>

--- a/docs/json-schema/schema-types/string.mdx
+++ b/docs/json-schema/schema-types/string.mdx
@@ -137,6 +137,7 @@ $timeSchema = Schema::string('appointment_time')
 | `JsonPointer` | JSON Pointer | `/users/123/name` |
 | `RelativeJsonPointer`† | Relative JSON Pointer | `1/name` |
 | `UriTemplate` | URI Template | `/users/{id}` |
+| `Regex`† | Regular expression pattern | `^[a-zA-Z0-9_]+$` |
 | `IdnEmail`† | Internationalized email | `用户@example.com` |
 | `IdnHostname`† | Internationalized hostname | `例え.テスト` |
 | `Iri`† | Internationalized URI | `https://例え.テスト` |

--- a/docs/json-schema/schema-types/string.mdx
+++ b/docs/json-schema/schema-types/string.mdx
@@ -147,6 +147,55 @@ $timeSchema = Schema::string('appointment_time')
 Formats marked with † require JSON Schema Draft-07 or later. Formats marked with * require Draft 2019-09 or later.
 </Note>
 
+## Content Annotations
+
+Describe encoded content carried by a string using `contentEncoding` and `contentMediaType`, and (optionally) validate the decoded content with `contentSchema`:
+
+```php
+use Cortex\JsonSchema\Enums\SchemaVersion;
+use Cortex\JsonSchema\Enums\SchemaFormat;
+
+$payloadSchema = Schema::string('payload', SchemaVersion::Draft_2019_09)
+    ->contentEncoding('base64')
+    ->contentMediaType('application/json')
+    ->contentSchema(
+        Schema::object()
+            ->properties(
+                Schema::string('event_id')->required(),
+                Schema::string('type')->required(),
+                Schema::string('created_at')->format(SchemaFormat::DateTime)->required(),
+                Schema::object('data')
+                    ->properties(
+                        Schema::string('user_id')->required(),
+                        Schema::string('email')->format(SchemaFormat::Email),
+                    )
+                    ->required(),
+            ),
+    );
+```
+
+<Note>
+`contentSchema` requires JSON Schema Draft 2019-09 or later. `contentEncoding` and `contentMediaType` are available in all supported versions.
+</Note>
+
+Validation examples:
+
+```php
+$payloadSchema->isValid(base64_encode(
+    json_encode([
+        'event_id' => 'evt_123',
+        'type' => 'user.created',
+        'created_at' => '2024-03-14T12:00:00Z',
+        'data' => [
+            'user_id' => 'usr_1',
+            'email' => 'ada@example.com',
+        ],
+    ], JSON_THROW_ON_ERROR),
+)); // true (base64 encoded string value and matches the content schema)
+
+$payloadSchema->isValid(123); // false (not a string)
+```
+
 ## Enumeration Values
 
 Restrict strings to a specific set of allowed values:
@@ -195,6 +244,10 @@ $passwordSchema = Schema::string('password')
     ->minLength(8)
     ->pattern('(?=.*[a-z])(?=.*[A-Z])(?=.*\d)');
 ```
+
+<Note>
+Read-only and write-only annotations require JSON Schema Draft-07 or later.
+</Note>
 
 ## Complex Example
 

--- a/docs/json-schema/schema-types/string.mdx
+++ b/docs/json-schema/schema-types/string.mdx
@@ -129,21 +129,21 @@ $timeSchema = Schema::string('appointment_time')
 | `Hostname` | Internet hostname | `example.com` |
 | `Ipv4` | IPv4 address | `192.168.1.1` |
 | `Ipv6` | IPv6 address | `2001:db8::1` |
-| `Date` | Full date (RFC 3339) | `2023-12-25` |
-| `Time` | Time (RFC 3339) | `14:30:00` |
+| `Date`† | Full date (RFC 3339) | `2023-12-25` |
+| `Time`† | Time (RFC 3339) | `14:30:00` |
 | `DateTime` | Date-time (RFC 3339) | `2023-12-25T14:30:00Z` |
 | `Duration` | Duration (ISO 8601)* | `P1Y2M3DT4H5M6S` |
 | `Uuid` | UUID string* | `123e4567-e89b-12d3-a456-426614174000` |
 | `JsonPointer` | JSON Pointer | `/users/123/name` |
-| `RelativeJsonPointer` | Relative JSON Pointer | `1/name` |
+| `RelativeJsonPointer`† | Relative JSON Pointer | `1/name` |
 | `UriTemplate` | URI Template | `/users/{id}` |
-| `IdnEmail` | Internationalized email | `用户@example.com` |
-| `IdnHostname` | Internationalized hostname | `例え.テスト` |
-| `Iri` | Internationalized URI | `https://例え.テスト` |
-| `IriReference` | IRI reference | `//例え.テスト/path` |
+| `IdnEmail`† | Internationalized email | `用户@example.com` |
+| `IdnHostname`† | Internationalized hostname | `例え.テスト` |
+| `Iri`† | Internationalized URI | `https://例え.テスト` |
+| `IriReference`† | IRI reference | `//例え.テスト/path` |
 
 <Note>
-Formats marked with * require JSON Schema Draft 2019-09 or later.
+Formats marked with † require JSON Schema Draft-07 or later. Formats marked with * require Draft 2019-09 or later.
 </Note>
 
 ## Enumeration Values

--- a/docs/json-schema/versions.mdx
+++ b/docs/json-schema/versions.mdx
@@ -9,8 +9,11 @@ icon: 'history'
 This package supports multiple JSON Schema specification versions with automatic feature validation to ensure compatibility.
 
 <CardGroup cols={1}>
+  <Card title="Draft-06 (2017)" icon="shield-check">
+    Legacy version for maximum compatibility with older tools. Includes core validation features and basic constraints.
+  </Card>
   <Card title="Draft-07 (2018)" icon="shield-check">
-    Legacy version for maximum compatibility across tools and libraries. Includes core validation features and basic conditionals.
+    Legacy version with broad compatibility across tools and libraries. Includes core validation features and conditionals.
   </Card>
   <Card title="Draft 2019-09" icon="star">
     Adds advanced features like `$defs`, `unevaluatedProperties`, `deprecated`, and enhanced array validation.
@@ -96,28 +99,28 @@ $arraySchema = Schema::array('items', SchemaVersion::Draft_07)
 
 ## Feature Support Matrix
 
-| Feature | Draft-07 | Draft 2019-09 | Draft 2020-12 | Description |
-|---------|----------|---------------|---------------|-------------|
+| Feature | Draft-06 | Draft-07 | Draft 2019-09 | Draft 2020-12 | Description |
+|---------|----------|----------|---------------|---------------|-------------|
 | **Core Validation** |
-| `minLength`, `maxLength`, `pattern` | ✅ | ✅ | ✅ | Basic string validation |
-| `minimum`, `maximum`, `multipleOf` | ✅ | ✅ | ✅ | Numeric constraints |
-| `minItems`, `maxItems`, `uniqueItems` | ✅ | ✅ | ✅ | Array validation |
-| `properties`, `required`, `additionalProperties` | ✅ | ✅ | ✅ | Object validation |
+| `minLength`, `maxLength`, `pattern` | ✅ | ✅ | ✅ | ✅ | Basic string validation |
+| `minimum`, `maximum`, `multipleOf` | ✅ | ✅ | ✅ | ✅ | Numeric constraints |
+| `minItems`, `maxItems`, `uniqueItems` | ✅ | ✅ | ✅ | ✅ | Array validation |
+| `properties`, `required`, `additionalProperties` | ✅ | ✅ | ✅ | ✅ | Object validation |
 | **Conditionals** |
-| `if`/`then`/`else` | ✅ | ✅ | ✅ | Conditional schemas |
-| `allOf`, `anyOf`, `oneOf`, `not` | ✅ | ✅ | ✅ | Logical combinations |
+| `if`/`then`/`else` | ❌ | ✅ | ✅ | ✅ | Conditional schemas |
+| `allOf`, `anyOf`, `oneOf`, `not` | ✅ | ✅ | ✅ | ✅ | Logical combinations |
 | **Advanced Features** |
-| `deprecated` | ❌ | ✅ | ✅ | Property deprecation |
-| `$defs` (replaces `definitions`) | ❌ | ✅ | ✅ | Schema definitions |
-| `minContains`, `maxContains` | ❌ | ✅ | ✅ | Array contains validation |
-| `unevaluatedProperties`, `unevaluatedItems` | ❌ | ✅ | ✅ | Strict validation |
-| `dependentSchemas` | ❌ | ✅ | ✅ | Property dependencies |
+| `deprecated` | ❌ | ❌ | ✅ | ✅ | Property deprecation |
+| `$defs` (replaces `definitions`) | ❌ | ❌ | ✅ | ✅ | Schema definitions |
+| `minContains`, `maxContains` | ❌ | ❌ | ✅ | ✅ | Array contains validation |
+| `unevaluatedProperties`, `unevaluatedItems` | ❌ | ❌ | ✅ | ✅ | Strict validation |
+| `dependentSchemas` | ❌ | ❌ | ✅ | ✅ | Property dependencies |
 | **Draft 2020-12 Only** |
-| `prefixItems` | ❌ | ❌ | ✅ | Tuple validation |
-| Dynamic references (`$dynamicRef`) | ❌ | ❌ | ✅ | Dynamic schema refs |
+| `prefixItems` | ❌ | ❌ | ❌ | ✅ | Tuple validation |
+| Dynamic references (`$dynamicRef`) | ❌ | ❌ | ❌ | ✅ | Dynamic schema refs |
 | **Formats** |
-| `email`, `uri`, `date-time` | ✅ | ✅ | ✅ | Basic formats |
-| `duration`, `uuid` | ❌ | ✅ | ✅ | Extended formats |
+| `email`, `uri`, `date-time` | ✅ | ✅ | ✅ | ✅ | Basic formats |
+| `duration`, `uuid` | ❌ | ❌ | ✅ | ✅ | Extended formats |
 
 ## Version-Appropriate Output
 
@@ -181,5 +184,5 @@ echo $feature->getMinimumVersion()->name; // "Draft201909"
 ```
 
 <Tip>
-The package defaults to Draft 2020-12 for the latest features. Use Draft-07 for maximum compatibility with older tools if needed.
+The package defaults to Draft 2020-12 for the latest features. Use Draft-06 for maximum compatibility with older tools if needed.
 </Tip>

--- a/src/Converters/JsonConverter.php
+++ b/src/Converters/JsonConverter.php
@@ -155,6 +155,7 @@ class JsonConverter implements Converter
     private function detectSchemaVersion(string $schemaUri): SchemaVersion
     {
         return match (true) {
+            str_contains($schemaUri, 'draft-06') => SchemaVersion::Draft_06,
             str_contains($schemaUri, 'draft-07') => SchemaVersion::Draft_07,
             str_contains($schemaUri, 'draft/2019-09') => SchemaVersion::Draft_2019_09,
             str_contains($schemaUri, 'draft/2020-12') => SchemaVersion::Draft_2020_12,

--- a/src/Enums/SchemaFeature.php
+++ b/src/Enums/SchemaFeature.php
@@ -9,7 +9,7 @@ namespace Cortex\JsonSchema\Enums;
  */
 enum SchemaFeature: string
 {
-    // Draft 07 features (available in all supported versions)
+    // Draft 07 features
     case If = 'if';
     case Then = 'then';
     case Else = 'else';
@@ -18,6 +18,15 @@ enum SchemaFeature: string
     case ContentEncoding = 'contentEncoding';
     case WriteOnly = 'writeOnly';
     case ReadOnly = 'readOnly';
+    case Comment = '$comment';
+    case FormatDate = 'format-date';
+    case FormatTime = 'format-time';
+    case FormatRegex = 'format-regex';
+    case FormatRelativeJsonPointer = 'format-relative-json-pointer';
+    case FormatIdnEmail = 'format-idn-email';
+    case FormatIdnHostname = 'format-idn-hostname';
+    case FormatIri = 'format-iri';
+    case FormatIriReference = 'format-iri-reference';
 
     // Draft 2019-09 new features
     case Anchor = '$anchor';
@@ -66,7 +75,16 @@ enum SchemaFeature: string
             self::ContentMediaType,
             self::ContentEncoding,
             self::WriteOnly,
-            self::ReadOnly => SchemaVersion::Draft_07,
+            self::ReadOnly,
+            self::Comment,
+            self::FormatDate,
+            self::FormatTime,
+            self::FormatRegex,
+            self::FormatRelativeJsonPointer,
+            self::FormatIdnEmail,
+            self::FormatIdnHostname,
+            self::FormatIri,
+            self::FormatIriReference => SchemaVersion::Draft_07,
 
             // Draft 2019-09 features
             self::Anchor,
@@ -135,6 +153,15 @@ enum SchemaFeature: string
             self::ContentEncoding => 'Content encoding annotation',
             self::WriteOnly => 'Write-only property annotation',
             self::ReadOnly => 'Read-only property annotation',
+            self::Comment => 'Schema annotation comment',
+            self::FormatDate => 'RFC 3339 full-date format validation',
+            self::FormatTime => 'RFC 3339 time format validation',
+            self::FormatRegex => 'Regular expression format validation',
+            self::FormatRelativeJsonPointer => 'Relative JSON Pointer format validation',
+            self::FormatIdnEmail => 'Internationalized email format validation',
+            self::FormatIdnHostname => 'Internationalized hostname format validation',
+            self::FormatIri => 'Internationalized URI format validation',
+            self::FormatIriReference => 'Internationalized URI reference format validation',
 
             self::Anchor => 'Plain name anchors for schema identification',
             self::Defs => 'Schema definitions (renamed from definitions)',

--- a/src/Enums/SchemaFormat.php
+++ b/src/Enums/SchemaFormat.php
@@ -18,6 +18,7 @@ enum SchemaFormat: string
     case UriTemplate = 'uri-template';
     case Uuid = 'uuid';
     case Hostname = 'hostname';
+    case IdnHostname = 'idn-hostname';
     case Ipv4 = 'ipv4';
     case Ipv6 = 'ipv6';
     case Iri = 'iri';

--- a/src/Enums/SchemaVersion.php
+++ b/src/Enums/SchemaVersion.php
@@ -6,6 +6,7 @@ namespace Cortex\JsonSchema\Enums;
 
 enum SchemaVersion: string
 {
+    case Draft_06 = 'http://json-schema.org/draft-06/schema#';
     case Draft_07 = 'http://json-schema.org/draft-07/schema#';
     case Draft_2019_09 = 'https://json-schema.org/draft/2019-09/schema';
     case Draft_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
@@ -34,6 +35,7 @@ enum SchemaVersion: string
     public static function supported(): array
     {
         return [
+            self::Draft_06,
             self::Draft_07,
             self::Draft_2019_09,
             self::Draft_2020_12,
@@ -63,6 +65,7 @@ enum SchemaVersion: string
     public function getName(): string
     {
         return match ($this) {
+            self::Draft_06 => 'Draft 6',
             self::Draft_07 => 'Draft 7',
             self::Draft_2019_09 => 'Draft 2019-09',
             self::Draft_2020_12 => 'Draft 2020-12',
@@ -75,6 +78,7 @@ enum SchemaVersion: string
     public function getYear(): int
     {
         return match ($this) {
+            self::Draft_06 => 2017,
             self::Draft_07 => 2018,
             self::Draft_2019_09 => 2019,
             self::Draft_2020_12 => 2020,

--- a/src/Types/AbstractSchema.php
+++ b/src/Types/AbstractSchema.php
@@ -7,6 +7,7 @@ namespace Cortex\JsonSchema\Types;
 use Cortex\JsonSchema\Enums\SchemaType;
 use Cortex\JsonSchema\Enums\SchemaVersion;
 use Cortex\JsonSchema\Contracts\JsonSchema;
+use Cortex\JsonSchema\Types\Concerns\HasId;
 use Cortex\JsonSchema\Types\Concerns\HasRef;
 use Cortex\JsonSchema\Types\Concerns\HasEnum;
 use Cortex\JsonSchema\Types\Concerns\HasConst;
@@ -25,6 +26,7 @@ use Cortex\JsonSchema\Types\Concerns\ValidatesVersionFeatures;
 abstract class AbstractSchema implements JsonSchema
 {
     use HasRef;
+    use HasId;
     use HasEnum;
     use HasConst;
     use HasTitle;
@@ -113,6 +115,7 @@ abstract class AbstractSchema implements JsonSchema
             $schema['$schema'] = $this->schemaVersion->value;
         }
 
+        $schema = $this->addIdToSchema($schema);
         $schema = $this->addTitleToSchema($schema, $includeTitle);
         $schema = $this->addFormatToSchema($schema);
         $schema = $this->addDescriptionToSchema($schema);

--- a/src/Types/Concerns/HasFormat.php
+++ b/src/Types/Concerns/HasFormat.php
@@ -53,6 +53,14 @@ trait HasFormat
         $feature = match ($schemaFormat) {
             SchemaFormat::Duration => SchemaFeature::FormatDuration,
             SchemaFormat::Uuid => SchemaFeature::FormatUuid,
+            SchemaFormat::Date => SchemaFeature::FormatDate,
+            SchemaFormat::Time => SchemaFeature::FormatTime,
+            SchemaFormat::Regex => SchemaFeature::FormatRegex,
+            SchemaFormat::RelativeJsonPointer => SchemaFeature::FormatRelativeJsonPointer,
+            SchemaFormat::IdnEmail => SchemaFeature::FormatIdnEmail,
+            SchemaFormat::IdnHostname => SchemaFeature::FormatIdnHostname,
+            SchemaFormat::Iri => SchemaFeature::FormatIri,
+            SchemaFormat::IriReference => SchemaFeature::FormatIriReference,
             // All other formats are available in all supported versions
             default => null,
         };
@@ -76,6 +84,30 @@ trait HasFormat
         $features = [];
 
         switch ($this->format) {
+            case SchemaFormat::Date:
+                $features[] = SchemaFeature::FormatDate;
+                break;
+            case SchemaFormat::Time:
+                $features[] = SchemaFeature::FormatTime;
+                break;
+            case SchemaFormat::Regex:
+                $features[] = SchemaFeature::FormatRegex;
+                break;
+            case SchemaFormat::RelativeJsonPointer:
+                $features[] = SchemaFeature::FormatRelativeJsonPointer;
+                break;
+            case SchemaFormat::IdnEmail:
+                $features[] = SchemaFeature::FormatIdnEmail;
+                break;
+            case SchemaFormat::IdnHostname:
+                $features[] = SchemaFeature::FormatIdnHostname;
+                break;
+            case SchemaFormat::Iri:
+                $features[] = SchemaFeature::FormatIri;
+                break;
+            case SchemaFormat::IriReference:
+                $features[] = SchemaFeature::FormatIriReference;
+                break;
             case SchemaFormat::Duration:
                 $features[] = SchemaFeature::FormatDuration;
                 break;

--- a/src/Types/Concerns/HasId.php
+++ b/src/Types/Concerns/HasId.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\JsonSchema\Types\Concerns;
+
+/** @mixin \Cortex\JsonSchema\Contracts\JsonSchema */
+trait HasId
+{
+    protected ?string $id = null;
+
+    /**
+     * Set the $id value for this schema.
+     */
+    public function id(string $id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get the $id value for this schema.
+     */
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Add $id to schema array.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    protected function addIdToSchema(array $schema): array
+    {
+        if ($this->id !== null) {
+            $schema['$id'] = $this->id;
+        }
+
+        return $schema;
+    }
+}

--- a/src/Types/Concerns/HasMetadata.php
+++ b/src/Types/Concerns/HasMetadata.php
@@ -52,6 +52,7 @@ trait HasMetadata
      */
     public function comment(string $comment): static
     {
+        $this->validateFeatureSupport(SchemaFeature::Comment);
         $this->comment = $comment;
 
         return $this;
@@ -108,6 +109,10 @@ trait HasMetadata
 
         if ($this->deprecated) {
             $features[] = SchemaFeature::Deprecated;
+        }
+
+        if ($this->comment !== null) {
+            $features[] = SchemaFeature::Comment;
         }
 
         return $features;

--- a/src/Types/Concerns/HasReadWrite.php
+++ b/src/Types/Concerns/HasReadWrite.php
@@ -18,6 +18,10 @@ trait HasReadWrite
      */
     public function readOnly(bool $readOnly = true): static
     {
+        if ($readOnly) {
+            $this->validateFeatureSupport(SchemaFeature::ReadOnly);
+        }
+
         $this->readOnly = $readOnly;
 
         return $this;
@@ -28,6 +32,10 @@ trait HasReadWrite
      */
     public function writeOnly(bool $writeOnly = true): static
     {
+        if ($writeOnly) {
+            $this->validateFeatureSupport(SchemaFeature::WriteOnly);
+        }
+
         $this->writeOnly = $writeOnly;
 
         return $this;

--- a/src/Types/Concerns/HasValidation.php
+++ b/src/Types/Concerns/HasValidation.php
@@ -23,6 +23,7 @@ trait HasValidation
     {
         $validator = new Validator();
         $validator->parser()->setOption('defaultDraft', '2020-12');
+        $validator->parser()->setOption('decodeContent', true);
 
         try {
             $result = $validator->validate(

--- a/src/Types/Concerns/HasValidation.php
+++ b/src/Types/Concerns/HasValidation.php
@@ -21,9 +21,7 @@ trait HasValidation
      */
     public function validate(mixed $value): void
     {
-        $validator = new Validator();
-        $validator->parser()->setOption('defaultDraft', '2020-12');
-        $validator->parser()->setOption('decodeContent', true);
+        $validator = $this->makeValidator();
 
         try {
             $result = $validator->validate(
@@ -53,5 +51,19 @@ trait HasValidation
         } catch (SchemaException) {
             return false;
         }
+    }
+
+    /**
+     * Create a configured validator instance.
+     */
+    private function makeValidator(): Validator
+    {
+        $validator = new Validator();
+        $parser = $validator->parser();
+
+        $parser->setOption('defaultDraft', '2020-12');
+        $parser->setOption('decodeContent', true);
+
+        return $validator;
     }
 }

--- a/src/Types/Concerns/ValidatesVersionFeatures.php
+++ b/src/Types/Concerns/ValidatesVersionFeatures.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Cortex\JsonSchema\Types\Concerns;
 
 use Cortex\JsonSchema\Enums\SchemaFeature;
-use Cortex\JsonSchema\Enums\SchemaVersion;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
 /** @mixin \Cortex\JsonSchema\Contracts\JsonSchema */
@@ -60,7 +59,7 @@ trait ValidatesVersionFeatures
     {
         // For features that were renamed, use the appropriate keyword for the version
         return match ($modernKeyword) {
-            '$defs' => $this->getVersion() === SchemaVersion::Draft_07 ? 'definitions' : '$defs',
+            '$defs' => $this->isFeatureSupported(SchemaFeature::Defs) ? '$defs' : 'definitions',
             default => $modernKeyword,
         };
     }

--- a/src/Types/StringSchema.php
+++ b/src/Types/StringSchema.php
@@ -201,6 +201,14 @@ final class StringSchema extends AbstractSchema
     {
         $features = [];
 
+        if ($this->contentEncoding !== null) {
+            $features[] = SchemaFeature::ContentEncoding;
+        }
+
+        if ($this->contentMediaType !== null) {
+            $features[] = SchemaFeature::ContentMediaType;
+        }
+
         if ($this->contentSchema !== null) {
             $features[] = SchemaFeature::ContentSchema;
         }

--- a/src/Types/StringSchema.php
+++ b/src/Types/StringSchema.php
@@ -79,6 +79,7 @@ final class StringSchema extends AbstractSchema
      */
     public function contentEncoding(string $contentEncoding): static
     {
+        $this->validateFeatureSupport(SchemaFeature::ContentEncoding);
         $this->contentEncoding = $contentEncoding;
 
         return $this;
@@ -89,6 +90,7 @@ final class StringSchema extends AbstractSchema
      */
     public function contentMediaType(string $contentMediaType): static
     {
+        $this->validateFeatureSupport(SchemaFeature::ContentMediaType);
         $this->contentMediaType = $contentMediaType;
 
         return $this;

--- a/src/Types/StringSchema.php
+++ b/src/Types/StringSchema.php
@@ -6,7 +6,9 @@ namespace Cortex\JsonSchema\Types;
 
 use Override;
 use Cortex\JsonSchema\Enums\SchemaType;
+use Cortex\JsonSchema\Enums\SchemaFeature;
 use Cortex\JsonSchema\Enums\SchemaVersion;
+use Cortex\JsonSchema\Contracts\JsonSchema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
 final class StringSchema extends AbstractSchema
@@ -16,6 +18,12 @@ final class StringSchema extends AbstractSchema
     protected ?int $maxLength = null;
 
     protected ?string $pattern = null;
+
+    protected ?string $contentEncoding = null;
+
+    protected ?string $contentMediaType = null;
+
+    protected JsonSchema|bool|null $contentSchema = null;
 
     public function __construct(?string $title = null, ?SchemaVersion $schemaVersion = null)
     {
@@ -67,6 +75,37 @@ final class StringSchema extends AbstractSchema
     }
 
     /**
+     * Set the content encoding.
+     */
+    public function contentEncoding(string $contentEncoding): static
+    {
+        $this->contentEncoding = $contentEncoding;
+
+        return $this;
+    }
+
+    /**
+     * Set the content media type.
+     */
+    public function contentMediaType(string $contentMediaType): static
+    {
+        $this->contentMediaType = $contentMediaType;
+
+        return $this;
+    }
+
+    /**
+     * Set the content schema.
+     */
+    public function contentSchema(JsonSchema|bool $contentSchema): static
+    {
+        $this->validateFeatureSupport(SchemaFeature::ContentSchema);
+        $this->contentSchema = $contentSchema;
+
+        return $this;
+    }
+
+    /**
      * Convert to array.
      *
      * @return array<string, mixed>
@@ -76,7 +115,31 @@ final class StringSchema extends AbstractSchema
     {
         $schema = parent::toArray($includeSchemaRef, $includeTitle);
 
-        return $this->addLengthToSchema($schema);
+        $schema = $this->addLengthToSchema($schema);
+
+        return $this->addContentToSchema($schema);
+    }
+
+    /**
+     * Get features used by this schema from all traits.
+     *
+     * @return array<\Cortex\JsonSchema\Enums\SchemaFeature>
+     */
+    #[Override]
+    protected function getUsedFeatures(): array
+    {
+        $features = [
+            ...parent::getUsedFeatures(),
+            ...$this->getContentFeatures(),
+        ];
+
+        $uniqueFeatures = [];
+
+        foreach ($features as $feature) {
+            $uniqueFeatures[$feature->value] = $feature;
+        }
+
+        return array_values($uniqueFeatures);
     }
 
     /**
@@ -101,5 +164,47 @@ final class StringSchema extends AbstractSchema
         }
 
         return $schema;
+    }
+
+    /**
+     * Add content keywords to schema array.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    protected function addContentToSchema(array $schema): array
+    {
+        if ($this->contentEncoding !== null) {
+            $schema['contentEncoding'] = $this->contentEncoding;
+        }
+
+        if ($this->contentMediaType !== null) {
+            $schema['contentMediaType'] = $this->contentMediaType;
+        }
+
+        if ($this->contentSchema !== null) {
+            $schema['contentSchema'] = $this->contentSchema instanceof JsonSchema
+                ? $this->contentSchema->toArray(includeSchemaRef: false, includeTitle: false)
+                : $this->contentSchema;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Get content features used by this schema.
+     *
+     * @return array<\Cortex\JsonSchema\Enums\SchemaFeature>
+     */
+    protected function getContentFeatures(): array
+    {
+        $features = [];
+
+        if ($this->contentSchema !== null) {
+            $features[] = SchemaFeature::ContentSchema;
+        }
+
+        return $features;
     }
 }

--- a/tests/Unit/Converters/JsonConverterTest.php
+++ b/tests/Unit/Converters/JsonConverterTest.php
@@ -233,6 +233,20 @@ it('detects schema version from $schema property', function (): void {
     expect($jsonSchema->toArray()['deprecated'])->toBe(true);
 });
 
+it('detects draft-06 schema version from $schema property', function (): void {
+    $json = [
+        '$schema' => 'http://json-schema.org/draft-06/schema#',
+        'type' => 'string',
+    ];
+
+    // Even though we pass Draft_07, it should detect Draft_06 from the $schema
+    $converter = new JsonConverter($json, SchemaVersion::Draft_07);
+    $jsonSchema = $converter->convert();
+
+    expect($jsonSchema)->toBeInstanceOf(StringSchema::class);
+    expect($jsonSchema->getVersion())->toBe(SchemaVersion::Draft_06);
+});
+
 it('can handle nested schemas', function (): void {
     $json = [
         'type' => 'object',

--- a/tests/Unit/Converters/JsonConverterTest.php
+++ b/tests/Unit/Converters/JsonConverterTest.php
@@ -350,3 +350,30 @@ it('can handle string with enum and const', function (): void {
         'default' => 'red',
     ]);
 });
+
+it('can handle string content annotations', function (): void {
+    $json = [
+        'type' => 'string',
+        'contentEncoding' => 'base64',
+        'contentMediaType' => 'application/json',
+        'contentSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                ],
+            ],
+        ],
+    ];
+
+    $converter = new JsonConverter($json, SchemaVersion::Draft_2019_09);
+    $jsonSchema = $converter->convert();
+
+    expect($jsonSchema)->toBeInstanceOf(StringSchema::class);
+
+    $output = $jsonSchema->toArray();
+    expect($output['contentEncoding'])->toBe('base64');
+    expect($output['contentMediaType'])->toBe('application/json');
+    expect($output['contentSchema']['type'])->toBe('object');
+    expect($output['contentSchema']['properties']['name']['type'])->toBe('string');
+});

--- a/tests/Unit/Converters/JsonConverterTest.php
+++ b/tests/Unit/Converters/JsonConverterTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Cortex\JsonSchema\Tests\Unit\Converters;
+
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Types\NullSchema;
 use Cortex\JsonSchema\Types\ArraySchema;

--- a/tests/Unit/DefinitionsSchemaTest.php
+++ b/tests/Unit/DefinitionsSchemaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Cortex\JsonSchema\Tests\Unit\Targets;
+namespace Cortex\JsonSchema\Tests\Unit;
 
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Enums\SchemaFormat;

--- a/tests/Unit/IdSchemaTest.php
+++ b/tests/Unit/IdSchemaTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\JsonSchema\Tests\Unit\Targets;
+
+use Cortex\JsonSchema\Schema;
+
+it('can create a schema with a $id', function (): void {
+    $stringSchema = Schema::string('name')
+        ->id('https://example.com/schemas/name');
+
+    $schemaArray = $stringSchema->toArray();
+
+    expect($schemaArray)->toHaveKey('$id', 'https://example.com/schemas/name');
+    expect($schemaArray)->toHaveKey('type', 'string');
+});
+
+it('can convert $id from JSON', function (): void {
+    $json = [
+        '$id' => 'https://example.com/schemas/name',
+        'type' => 'string',
+    ];
+
+    $jsonSchema = Schema::fromJson($json);
+
+    expect($jsonSchema->toArray())->toHaveKey('$id', 'https://example.com/schemas/name');
+});

--- a/tests/Unit/IdSchemaTest.php
+++ b/tests/Unit/IdSchemaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Cortex\JsonSchema\Tests\Unit\Targets;
+namespace Cortex\JsonSchema\Tests\Unit;
 
 use Cortex\JsonSchema\Schema;
 

--- a/tests/Unit/RefSchemaTest.php
+++ b/tests/Unit/RefSchemaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Cortex\JsonSchema\Tests\Unit\Targets;
+namespace Cortex\JsonSchema\Tests\Unit;
 
 use Cortex\JsonSchema\Schema;
 

--- a/tests/Unit/Support/DocParserTest.php
+++ b/tests/Unit/Support/DocParserTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Cortex\JsonSchema\Tests\Unit;
+namespace Cortex\JsonSchema\Tests\Unit\Support;
 
 use ReflectionClass;
 use Cortex\JsonSchema\Support\NodeData;

--- a/tests/Unit/Types/DependentSchemasTest.php
+++ b/tests/Unit/Types/DependentSchemasTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+namespace Cortex\JsonSchema\Tests\Unit\Types;
+
+use ReflectionClass;
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Enums\SchemaFormat;
 use Cortex\JsonSchema\Types\ObjectSchema;

--- a/tests/Unit/Types/StringSchemaTest.php
+++ b/tests/Unit/Types/StringSchemaTest.php
@@ -8,8 +8,8 @@ use ReflectionClass;
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Enums\SchemaFormat;
 use Cortex\JsonSchema\Types\StringSchema;
-use Cortex\JsonSchema\Enums\SchemaVersion;
 use Cortex\JsonSchema\Enums\SchemaFeature;
+use Cortex\JsonSchema\Enums\SchemaVersion;
 use Cortex\JsonSchema\Exceptions\SchemaException;
 
 covers(StringSchema::class);
@@ -285,9 +285,9 @@ it('detects content features correctly', function (): void {
         ->contentSchema(Schema::object());
 
     $reflection = new ReflectionClass($stringSchema);
-    $contentFeaturesMethod = $reflection->getMethod('getContentFeatures');
+    $reflectionMethod = $reflection->getMethod('getContentFeatures');
 
-    $contentFeatures = $contentFeaturesMethod->invoke($stringSchema);
+    $contentFeatures = $reflectionMethod->invoke($stringSchema);
 
     expect($contentFeatures)->toContain(SchemaFeature::ContentEncoding);
     expect($contentFeatures)->toContain(SchemaFeature::ContentMediaType);

--- a/tests/Unit/Types/UnevaluatedItemsTest.php
+++ b/tests/Unit/Types/UnevaluatedItemsTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+namespace Cortex\JsonSchema\Tests\Unit\Types;
+
+use ReflectionClass;
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Types\ArraySchema;
 use Cortex\JsonSchema\Enums\SchemaVersion;

--- a/tests/Unit/Types/UnevaluatedPropertiesTest.php
+++ b/tests/Unit/Types/UnevaluatedPropertiesTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+namespace Cortex\JsonSchema\Tests\Unit\Types;
+
+use ReflectionClass;
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Enums\SchemaVersion;

--- a/tests/Unit/VersionFeatureValidationTest.php
+++ b/tests/Unit/VersionFeatureValidationTest.php
@@ -430,11 +430,17 @@ it('validates content encoding and media type features against schema version', 
     $draft202012Schema = Schema::string('test', SchemaVersion::Draft_2020_12);
 
     expect(fn(): StringSchema => $draft07Schema->contentEncoding('base64'))->not->toThrow(SchemaException::class);
-    expect(fn(): StringSchema => $draft07Schema->contentMediaType('application/json'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft07Schema->contentMediaType('application/json'))->not->toThrow(
+        SchemaException::class,
+    );
     expect(fn(): StringSchema => $draft201909Schema->contentEncoding('base64'))->not->toThrow(SchemaException::class);
-    expect(fn(): StringSchema => $draft201909Schema->contentMediaType('application/json'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft201909Schema->contentMediaType('application/json'))->not->toThrow(
+        SchemaException::class,
+    );
     expect(fn(): StringSchema => $draft202012Schema->contentEncoding('base64'))->not->toThrow(SchemaException::class);
-    expect(fn(): StringSchema => $draft202012Schema->contentMediaType('application/json'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft202012Schema->contentMediaType('application/json'))->not->toThrow(
+        SchemaException::class,
+    );
 });
 
 it('allows string formats for custom validation', function (): void {

--- a/tests/Unit/VersionFeatureValidationTest.php
+++ b/tests/Unit/VersionFeatureValidationTest.php
@@ -411,6 +411,32 @@ it('detects format features correctly', function (): void {
     expect($emailFormatFeatures)->toBeEmpty();
 });
 
+it('validates content encoding and media type features against schema version', function (): void {
+    // Draft 06 should reject contentEncoding/contentMediaType
+    $stringSchema = Schema::string('test', SchemaVersion::Draft_06);
+
+    expect(fn(): StringSchema => $stringSchema->contentEncoding('base64'))->toThrow(
+        SchemaException::class,
+        'Feature "Content encoding annotation" is not supported in Draft 6. Minimum version required: Draft 7.',
+    );
+    expect(fn(): StringSchema => $stringSchema->contentMediaType('application/json'))->toThrow(
+        SchemaException::class,
+        'Feature "Content media type annotation" is not supported in Draft 6. Minimum version required: Draft 7.',
+    );
+
+    // Draft 07+ should accept contentEncoding/contentMediaType
+    $draft07Schema = Schema::string('test', SchemaVersion::Draft_07);
+    $draft201909Schema = Schema::string('test', SchemaVersion::Draft_2019_09);
+    $draft202012Schema = Schema::string('test', SchemaVersion::Draft_2020_12);
+
+    expect(fn(): StringSchema => $draft07Schema->contentEncoding('base64'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft07Schema->contentMediaType('application/json'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft201909Schema->contentEncoding('base64'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft201909Schema->contentMediaType('application/json'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft202012Schema->contentEncoding('base64'))->not->toThrow(SchemaException::class);
+    expect(fn(): StringSchema => $draft202012Schema->contentMediaType('application/json'))->not->toThrow(SchemaException::class);
+});
+
 it('allows string formats for custom validation', function (): void {
     // String formats should not trigger validation (for custom formats)
     $stringSchema = Schema::string('test', SchemaVersion::Draft_07);

--- a/tests/Unit/VersionFeatureValidationTest.php
+++ b/tests/Unit/VersionFeatureValidationTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+namespace Cortex\JsonSchema\Tests\Unit;
+
+use ReflectionClass;
 use Cortex\JsonSchema\Schema;
 use Cortex\JsonSchema\Types\ArraySchema;
 use Cortex\JsonSchema\Enums\SchemaFormat;

--- a/tests/Unit/VersionSupportTest.php
+++ b/tests/Unit/VersionSupportTest.php
@@ -16,92 +16,132 @@ afterEach(function (): void {
 });
 
 it('has correct schema version enum values', function (): void {
+    expect(SchemaVersion::Draft_06->value)->toBe('http://json-schema.org/draft-06/schema#');
     expect(SchemaVersion::Draft_07->value)->toBe('http://json-schema.org/draft-07/schema#');
     expect(SchemaVersion::Draft_2019_09->value)->toBe('https://json-schema.org/draft/2019-09/schema');
     expect(SchemaVersion::Draft_2020_12->value)->toBe('https://json-schema.org/draft/2020-12/schema');
 });
 
 it('has correct schema version names', function (): void {
+    expect(SchemaVersion::Draft_06->getName())->toBe('Draft 6');
     expect(SchemaVersion::Draft_07->getName())->toBe('Draft 7');
     expect(SchemaVersion::Draft_2019_09->getName())->toBe('Draft 2019-09');
     expect(SchemaVersion::Draft_2020_12->getName())->toBe('Draft 2020-12');
 });
 
 it('has correct schema version years', function (): void {
+    expect(SchemaVersion::Draft_06->getYear())->toBe(2017);
     expect(SchemaVersion::Draft_07->getYear())->toBe(2018);
     expect(SchemaVersion::Draft_2019_09->getYear())->toBe(2019);
     expect(SchemaVersion::Draft_2020_12->getYear())->toBe(2020);
 });
 
 it('has correct schema version feature support', function (): void {
+    $draft06 = SchemaVersion::Draft_06;
     $draft07 = SchemaVersion::Draft_07;
     $draft201909 = SchemaVersion::Draft_2019_09;
     $draft202012 = SchemaVersion::Draft_2020_12;
 
-    // Draft 07 features (available in all versions)
+    // Draft 07 features
+    expect($draft06->supports(SchemaFeature::IfThenElse))->toBeFalse();
     expect($draft07->supports(SchemaFeature::IfThenElse))->toBeTrue();
     expect($draft201909->supports(SchemaFeature::IfThenElse))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::IfThenElse))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::ContentMediaType))->toBeFalse();
     expect($draft07->supports(SchemaFeature::ContentMediaType))->toBeTrue();
     expect($draft201909->supports(SchemaFeature::ContentMediaType))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::ContentMediaType))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::Comment))->toBeFalse();
+    expect($draft07->supports(SchemaFeature::Comment))->toBeTrue();
+    expect($draft201909->supports(SchemaFeature::Comment))->toBeTrue();
+    expect($draft202012->supports(SchemaFeature::Comment))->toBeTrue();
+
     // Draft 2019-09 new features
+    expect($draft06->supports(SchemaFeature::Anchor))->toBeFalse();
     expect($draft07->supports(SchemaFeature::Anchor))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::Anchor))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::Anchor))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::Defs))->toBeFalse();
     expect($draft07->supports(SchemaFeature::Defs))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::Defs))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::Defs))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::UnevaluatedProperties))->toBeFalse();
     expect($draft07->supports(SchemaFeature::UnevaluatedProperties))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::UnevaluatedProperties))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::UnevaluatedProperties))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::DependentRequired))->toBeFalse();
     expect($draft07->supports(SchemaFeature::DependentRequired))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::DependentRequired))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::DependentRequired))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::ContentSchema))->toBeFalse();
     expect($draft07->supports(SchemaFeature::ContentSchema))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::ContentSchema))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::ContentSchema))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::Deprecated))->toBeFalse();
     expect($draft07->supports(SchemaFeature::Deprecated))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::Deprecated))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::Deprecated))->toBeTrue();
 
     // 2019-09 only features (replaced in 2020-12)
+    expect($draft06->supports(SchemaFeature::RecursiveRefLegacy))->toBeFalse();
     expect($draft07->supports(SchemaFeature::RecursiveRefLegacy))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::RecursiveRefLegacy))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::RecursiveRefLegacy))->toBeFalse();
 
+    expect($draft06->supports(SchemaFeature::RecursiveRef))->toBeFalse();
     expect($draft07->supports(SchemaFeature::RecursiveRef))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::RecursiveRef))->toBeTrue();
     expect($draft202012->supports(SchemaFeature::RecursiveRef))->toBeFalse(); // Replaced by $dynamicRef in 2020-12
 
     // Draft 2020-12 features
+    expect($draft06->supports(SchemaFeature::DynamicRef))->toBeFalse();
     expect($draft07->supports(SchemaFeature::DynamicRef))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::DynamicRef))->toBeFalse();
     expect($draft202012->supports(SchemaFeature::DynamicRef))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::PrefixItems))->toBeFalse();
     expect($draft07->supports(SchemaFeature::PrefixItems))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::PrefixItems))->toBeFalse();
     expect($draft202012->supports(SchemaFeature::PrefixItems))->toBeTrue();
 
     // 2020-12 vocabulary and format changes
+    expect($draft06->supports(SchemaFeature::FormatAnnotation))->toBeFalse();
     expect($draft07->supports(SchemaFeature::FormatAnnotation))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::FormatAnnotation))->toBeFalse();
     expect($draft202012->supports(SchemaFeature::FormatAnnotation))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::UnevaluatedVocabulary))->toBeFalse();
     expect($draft07->supports(SchemaFeature::UnevaluatedVocabulary))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::UnevaluatedVocabulary))->toBeFalse();
     expect($draft202012->supports(SchemaFeature::UnevaluatedVocabulary))->toBeTrue();
 
+    expect($draft06->supports(SchemaFeature::UnicodeRegex))->toBeFalse();
     expect($draft07->supports(SchemaFeature::UnicodeRegex))->toBeFalse();
     expect($draft201909->supports(SchemaFeature::UnicodeRegex))->toBeFalse();
     expect($draft202012->supports(SchemaFeature::UnicodeRegex))->toBeTrue();
+
+    // Draft 07 format additions
+    expect($draft06->supports(SchemaFeature::FormatDate))->toBeFalse();
+    expect($draft07->supports(SchemaFeature::FormatDate))->toBeTrue();
+    expect($draft201909->supports(SchemaFeature::FormatDate))->toBeTrue();
+    expect($draft202012->supports(SchemaFeature::FormatDate))->toBeTrue();
+
+    expect($draft06->supports(SchemaFeature::FormatIdnEmail))->toBeFalse();
+    expect($draft07->supports(SchemaFeature::FormatIdnEmail))->toBeTrue();
+    expect($draft201909->supports(SchemaFeature::FormatIdnEmail))->toBeTrue();
+    expect($draft202012->supports(SchemaFeature::FormatIdnEmail))->toBeTrue();
+
+    expect($draft06->supports(SchemaFeature::FormatIdnHostname))->toBeFalse();
+    expect($draft07->supports(SchemaFeature::FormatIdnHostname))->toBeTrue();
+    expect($draft201909->supports(SchemaFeature::FormatIdnHostname))->toBeTrue();
+    expect($draft202012->supports(SchemaFeature::FormatIdnHostname))->toBeTrue();
 });
 
 it('supports enum-based feature checks', function (): void {
@@ -161,12 +201,15 @@ it('can manage schema factory default version', function (): void {
 });
 
 it('includes correct schema version in output', function (): void {
+    $draft06Schema = Schema::string('test', SchemaVersion::Draft_06);
     $stringSchema = Schema::string('test', SchemaVersion::Draft_07);
     $draft202012Schema = Schema::string('test', SchemaVersion::Draft_2020_12);
 
+    $draft06Array = $draft06Schema->toArray();
     $draft07Array = $stringSchema->toArray();
     $draft202012Array = $draft202012Schema->toArray();
 
+    expect($draft06Array['$schema'])->toBe('http://json-schema.org/draft-06/schema#');
     expect($draft07Array['$schema'])->toBe('http://json-schema.org/draft-07/schema#');
     expect($draft202012Array['$schema'])->toBe('https://json-schema.org/draft/2020-12/schema');
 });


### PR DESCRIPTION
This pull request adds support for JSON Schema Draft-06 throughout the documentation and codebase, making it the new default for maximum compatibility with older tools. It updates all feature and format support tables, revises documentation to highlight Draft-06, and extends the converter logic to properly detect and handle Draft-06 schemas. Additionally, it improves string schema support by enabling content annotations (`contentEncoding`, `contentMediaType`, `contentSchema`) and ensures shared fields like `$id` are applied consistently across all schema types.

**Documentation updates for Draft-06 support:**
* Added Draft-06 as a supported version in all documentation, updated feature and format tables, and revised recommendations to make Draft-06 the default for maximum compatibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28) [[3]](diffhunk://#diff-c78901f1d723ac3065bab1e1c293a85eed61476fbc2a01392fea61f80eca7affL26-R26) [[4]](diffhunk://#diff-c78901f1d723ac3065bab1e1c293a85eed61476fbc2a01392fea61f80eca7affL160-R173) [[5]](diffhunk://#diff-d58c942b7f9e2dfd3f6fa9f31212cabf0c6468f9597776dd14d482c1b5776dafL261-R261) [[6]](diffhunk://#diff-d58c942b7f9e2dfd3f6fa9f31212cabf0c6468f9597776dd14d482c1b5776dafL325-R325) [[7]](diffhunk://#diff-4de93031f4bfbc502ec4b9075dca25b5d5ec1478565632871b80df360805bd29L29-R29) [[8]](diffhunk://#diff-a2383679a604abb2d94fe4d8d0182f314d8c8ff82fbef8df639bcf02c88c4ee3R12-R16) [[9]](diffhunk://#diff-a2383679a604abb2d94fe4d8d0182f314d8c8ff82fbef8df639bcf02c88c4ee3L99-R123) [[10]](diffhunk://#diff-a2383679a604abb2d94fe4d8d0182f314d8c8ff82fbef8df639bcf02c88c4ee3L184-R187) [[11]](diffhunk://#diff-9198cc84e0b48026a9a39166ba269f2c17eb75115f83666d9e09cddbe658990aL176-R197) [[12]](diffhunk://#diff-8beede4a46cb795a98472b8f06709a4779da9f90f8b85eb8e8ba16a29566957bL132-R198)

**Feature and format matrix improvements:**
* Updated all feature and format support tables to include Draft-06, clarified which features/formats require Draft-07 or later, and added new format rows for extended string types. [[1]](diffhunk://#diff-9198cc84e0b48026a9a39166ba269f2c17eb75115f83666d9e09cddbe658990aL176-R197) [[2]](diffhunk://#diff-8beede4a46cb795a98472b8f06709a4779da9f90f8b85eb8e8ba16a29566957bL132-R198) [[3]](diffhunk://#diff-8beede4a46cb795a98472b8f06709a4779da9f90f8b85eb8e8ba16a29566957bR248-R251) [[4]](diffhunk://#diff-a2383679a604abb2d94fe4d8d0182f314d8c8ff82fbef8df639bcf02c88c4ee3L99-R123)

**Converter enhancements for Draft-06 and content annotations:**
* Extended `JsonConverter` to detect Draft-06 schemas, apply `$id` to all schema types, and support content annotations (`contentEncoding`, `contentMediaType`, `contentSchema`) for string schemas. [[1]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R21) [[2]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R153-R169) [[3]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R180) [[4]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R194-R210) [[5]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R250) [[6]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R295) [[7]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R340) [[8]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R364) [[9]](diffhunk://#diff-d077417354becc5bce694898d41df4b9fd0f6d34624d98e79f2d52771f64d630R408)

**Default version and compatibility messaging:**
* Changed all documentation and code examples to recommend Draft-06 as the default version for maximum compatibility, replacing previous recommendations for Draft-07. [[1]](diffhunk://#diff-4de93031f4bfbc502ec4b9075dca25b5d5ec1478565632871b80df360805bd29L29-R29) [[2]](diffhunk://#diff-d58c942b7f9e2dfd3f6fa9f31212cabf0c6468f9597776dd14d482c1b5776dafL261-R261) [[3]](diffhunk://#diff-d58c942b7f9e2dfd3f6fa9f31212cabf0c6468f9597776dd14d482c1b5776dafL325-R325) [[4]](diffhunk://#diff-a2383679a604abb2d94fe4d8d0182f314d8c8ff82fbef8df639bcf02c88c4ee3L184-R187) [[5]](diffhunk://#diff-c78901f1d723ac3065bab1e1c293a85eed61476fbc2a01392fea61f80eca7affL160-R173)

**String schema documentation improvements:**
* Clarified which string formats and annotations require Draft-07 or later, and added documentation/examples for content annotations and their version requirements. [[1]](diffhunk://#diff-8beede4a46cb795a98472b8f06709a4779da9f90f8b85eb8e8ba16a29566957bL132-R198) [[2]](diffhunk://#diff-8beede4a46cb795a98472b8f06709a4779da9f90f8b85eb8e8ba16a29566957bR248-R251)