### PR TITLE
refactor: Add array generics support to converters and address some bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - 📝 **Multi-Version Support** - Support for JSON Schema Draft-06, Draft-07, Draft 2019-09, and Draft 2020-12
 - ✅ **Validation** - Validate data against schemas with detailed error messages
 - 🤝 **Conditional Schemas** - Support for if/then/else, allOf, anyOf, and not conditions
-- 🔄 **Reflection** - Generate schemas from PHP Classes, Enums and Closures
+- 🔄 **Reflection** - Generate schemas from PHP classes, enums, and closures — including docblock array generics and constructor property promotion
 - 💪 **Type Safety** - Built with PHP 8.3+ features and strict typing
 - 🔍 **Version-Aware Features** - Automatic validation of version-specific features with helpful error messages
 

--- a/docs/json-schema/code-generation/from-classes.mdx
+++ b/docs/json-schema/code-generation/from-classes.mdx
@@ -4,7 +4,7 @@ description: 'Generate JSON schemas automatically from PHP class definitions'
 icon: 'code'
 ---
 
-Generate JSON schemas automatically from PHP classes using reflection and docblock analysis. This feature extracts property types, validation rules, and documentation from your existing PHP classes.
+Generate JSON schemas automatically from PHP classes using reflection and docblock analysis. This feature extracts property types, defaults, documentation, and array element types from your existing PHP classes.
 
 ## Basic Class Schema Generation
 
@@ -113,7 +113,7 @@ class Product
     public bool $in_stock = true;
 
     /**
-     * @var array Product tags
+     * @var string[] Product tags
      */
     public array $tags = [];
 }
@@ -155,6 +155,9 @@ $schema = Schema::fromClass(Product::class);
         "tags": {
             "type": "array",
             "description": "Product tags",
+            "items": {
+                "type": "string"
+            },
             "default": []
         }
     },
@@ -188,11 +191,64 @@ class ModernUser
 // Generate with Draft 2019-09 for deprecated support
 $schema = Schema::fromClass(
     ModernUser::class,
-    version: SchemaVersion::Draft_2019_09
+    schemaVersion: SchemaVersion::Draft_2019_09
 );
 
 // The generated schema will include "deprecated": true for old_email
 ```
+
+## Constructor Property Promotion
+
+Promoted constructor properties are supported. Descriptions and array element types are read from the constructor's `@param` tags when the property itself has no docblock:
+
+```php
+/**
+ * User data transfer object
+ *
+ * @param string $name The user's full name
+ * @param int $age The user's age in years
+ */
+class UserDto
+{
+    public function __construct(
+        public string $name,
+        public int $age = 18,
+    ) {}
+}
+
+$schema = Schema::fromClass(UserDto::class);
+// name: required string with @param description
+// age: optional integer with default 18
+```
+
+An explicit `@var` tag on a promoted property takes precedence over the matching `@param` description.
+
+## Array Item Types
+
+When a property is typed as `array`, the converter reads element types from docblock generics and adds an `items` schema. Supported syntax includes:
+
+- `string[]` and `(int|string)[]`
+- `array<string>`, `array<int|string>`, and `array<string, int>` (value type is used for key-value maps)
+- `list<bool>`, `non-empty-array<string>`, and similar list/array generics
+
+```php
+class Article
+{
+    /** @var string[] Article tags */
+    public array $tags;
+
+    /** @var array<int|string> Flexible identifiers */
+    public array $ids;
+}
+
+$schema = Schema::fromClass(Article::class);
+// tags: { "type": "array", "items": { "type": "string" } }
+// ids: { "type": "array", "items": { "type": ["integer", "string"] } }
+```
+
+<Note>
+Array item types are limited to JSON Schema scalar types (`string`, `integer`, `number`, `boolean`, `null`, `object`, `array`) and unions of those scalars. Class names (e.g. `DateTime[]`), `mixed`, and nested generics (e.g. `array<array<int>>`) are skipped silently, leaving a plain `array` without `items`.
+</Note>
 
 ## Complex Property Types
 
@@ -210,7 +266,7 @@ class Order
     public string $id;
 
     /**
-     * @var array List of order items
+     * @var array<string> List of order item SKUs
      */
     public array $items;
 
@@ -225,25 +281,50 @@ class Order
     public ?object $billing_address = null;
 
     /**
-     * @var array Additional notes
+     * @var string[] Additional notes
      */
     public array $notes = [];
 
     /**
-     * @var array Metadata key-value pairs
+     * @var array<string, string> Metadata key-value pairs
      */
     public array $metadata = [];
 }
 
 $schema = Schema::fromClass(Order::class);
-// Custom class types (like Address) are treated as generic 'object' type
-// Generic array syntax (e.g., array<OrderItem>) in docblocks is not parsed
-// Arrays are treated as generic arrays without item type information
+// items, notes, and metadata include string item schemas
+// Custom class types (like Address) require ignoreUnknownTypes or separate schema generation
 ```
 
 <Note>
-Custom class types (non-built-in PHP types) are converted to generic `object` schemas. The converter does not recursively analyze nested classes or parse generic array syntax from docblocks. To create schemas for nested objects, generate them separately and combine them using the fluent API.
+Custom class types (non-built-in PHP types) are not mapped to JSON Schema types by default and will throw an `UnknownTypeException`. Use `ignoreUnknownTypes: true` to skip unmappable properties, or generate nested object schemas separately and combine them using the fluent API.
 </Note>
+
+## Handling Unknown Types
+
+By default, properties typed as custom classes (e.g. `DateTime`, `Address`) cause conversion to fail. Pass `ignoreUnknownTypes: true` to omit those properties from the generated schema:
+
+```php
+class Event
+{
+    public string $title;
+
+    public DateTime $starts_at;
+
+    public ?DateTime $ends_at = null;
+}
+
+// Throws UnknownTypeException for DateTime properties
+$schema = Schema::fromClass(Event::class);
+
+// Skips DateTime properties, includes title only
+$schema = Schema::fromClass(
+    Event::class,
+    ignoreUnknownTypes: true,
+);
+```
+
+This option is also available on `Schema::from()` when passing a class or object instance.
 
 ## Enum Integration
 
@@ -363,8 +444,13 @@ class CompleteUser extends BaseEntity
 }
 
 $schema = Schema::fromClass(CompleteUser::class);
-// Schema will include properties from base class and traits
+// Schema includes properties from the base class and traits
+// Static properties are excluded
 ```
+
+<Note>
+Only **public** properties are included by default. Pass `publicOnly: false` to include protected and private properties. Static properties are always excluded.
+</Note>
 
 ## Validation and Usage
 
@@ -418,13 +504,14 @@ if ($userSchema->isValid($userData)) {
 
 The schema generator automatically extracts the following from your docblocks:
 
-- **Description text** - From the docblock summary and description
-- **Property types** - From `@var` annotations (combined with native PHP types)
-- **Parameter types** - From `@param` annotations
-- **Deprecation status** - Using the `@deprecated` tag
+- **Description text** - From the class docblock summary and `@var` property descriptions
+- **Promoted property descriptions** - From matching constructor `@param` tags when no `@var` is present
+- **Property types** - From native PHP type hints (combined with `@var` where present)
+- **Array item types** - From generic array syntax in `@var` or `@param` tags (scalar element types only)
+- **Deprecation status** - Using the `@deprecated` tag on classes and properties
 
 <Note>
-Validation rules (like minLength, pattern, format) are **not** extracted from docblocks. You need to apply them programmatically using the fluent API after generation, or define them in your actual PHP code using native types and enums.
+Validation rules (like minLength, pattern, format) are **not** extracted from docblocks. Apply them programmatically using the fluent API after generation, or rely on native PHP types and backed enums for type validation.
 </Note>
 
 ## Best Practices
@@ -485,7 +572,7 @@ public string $email;
  */
 public string $username;
 
-// Good: Document complex array types
+// Good: Document array element types with generics
 /**
  * @var array<string> List of user roles
  */
@@ -493,7 +580,7 @@ public array $roles;
 ```
 
 <Note>
-Validation rules like minLength, pattern, format are not extracted from docblocks. Generic array syntax (e.g., `array<string>`, `array<OrderItem>`) in docblocks is not parsed - arrays are treated as generic arrays without item type information. Apply validation rules and array item schemas programmatically using the fluent API after schema generation, or use native PHP types and enums for type validation.
+Validation rules like minLength, pattern, and format are not extracted from docblocks. Array item types are inferred from generic syntax for scalar elements only — nested object or array element types (e.g. `array<OrderItem>`) are not resolved recursively. Apply additional validation programmatically using the fluent API after schema generation.
 </Note>
 
 ## Common Use Cases

--- a/docs/json-schema/code-generation/from-closures.mdx
+++ b/docs/json-schema/code-generation/from-closures.mdx
@@ -68,7 +68,7 @@ Handle optional parameters with default values:
  * @param float $price Product price in USD
  * @param string $description Product description
  * @param bool $active Whether the product is active
- * @param array $tags Product tags
+ * @param string[] $tags Product tags
  */
 $createProductClosure = function (
     string $name,
@@ -111,6 +111,9 @@ $schema = Schema::fromClosure($createProductClosure);
         "tags": {
             "type": "array",
             "description": "Product tags",
+            "items": {
+                "type": "string"
+            },
             "default": []
         }
     },
@@ -183,6 +186,41 @@ The generated schema will include nullable types:
 }
 ```
 </Accordion>
+
+## Array Item Types
+
+When a parameter is typed as `array`, element types from generic docblock syntax are added as an `items` schema:
+
+```php
+/**
+ * Tag a resource with labels
+ *
+ * @param string[] $tags Resource tags
+ * @param array<int|string> $ids Associated identifiers
+ */
+$tagResourceClosure = function (array $tags, array $ids): void {};
+
+$schema = Schema::fromClosure($tagResourceClosure);
+// tags: { "type": "array", "items": { "type": "string" } }
+// ids: { "type": "array", "items": { "type": ["integer", "string"] } }
+```
+
+Supported syntax matches class property docblocks: `T[]`, `array<T>`, `list<T>`, `array<K,V>`, and unions of scalar element types. Class names, `mixed`, and nested generics are skipped silently.
+
+## Handling Unknown Types
+
+Parameters typed as custom classes throw an `UnknownTypeException` by default. Pass `ignoreUnknownTypes: true` to skip unmappable parameters:
+
+```php
+/**
+ * @param string $title Event title
+ * @param DateTime $starts_at Start time
+ */
+$createEvent = function (string $title, DateTime $starts_at): void {};
+
+$schema = Schema::fromClosure($createEvent, ignoreUnknownTypes: true);
+// Only includes title
+```
 
 ## Advanced Parameter Documentation
 
@@ -261,7 +299,7 @@ Real-world example for API endpoint validation:
  * @param ?string $email Email filter
  * @param ?int $age_min Minimum age filter
  * @param ?int $age_max Maximum age filter
- * @param array $roles Role filter
+ * @param array<string> $roles Role filter
  * @param int $page Page number for pagination
  * @param int $per_page Items per page
  * @param string $sort_by Sort field
@@ -319,7 +357,7 @@ $modernApiClosure = function (
 // Generate with Draft 2019-09 for deprecated support
 $modernSchema = Schema::fromClosure(
     $modernApiClosure,
-    version: SchemaVersion::Draft_2019_09
+    schemaVersion: SchemaVersion::Draft_2019_09
 );
 
 // Apply validation rules programmatically after generation
@@ -429,7 +467,7 @@ function processData($name, $age, $tags, $date) {}
 ```
 
 <Note>
-Validation rules like format, minLength, pattern are not extracted from docblocks. Generic array syntax (e.g., `array<string>`, `array<OrderItem>`) in docblocks is not parsed - arrays are treated as generic arrays without item type information. Only parameter types and descriptions are extracted. Apply validation rules and array item schemas programmatically using the fluent API after schema generation.
+Validation rules like format, minLength, and pattern are not extracted from docblocks. Array item types are inferred from generic syntax for scalar elements only. Apply additional validation programmatically using the fluent API after schema generation.
 </Note>
 
 ### 4. Design Functions for Schema Generation
@@ -451,7 +489,7 @@ function handleUserStuff($data, $action, $options = []) {}
 | `int` | `integer` | Integer numbers |
 | `float` | `number` | Floating-point numbers |
 | `bool` | `boolean` | Boolean true/false |
-| `array` | `array` | Generic arrays |
+| `array` | `array` | Generic arrays; `items` added when docblock specifies element types |
 | `?string` | `["string", "null"]` | Nullable string |
 | `mixed` | No type constraint | Accepts any type |
 | `object` | `object` | Generic object |

--- a/docs/json-schema/introduction.mdx
+++ b/docs/json-schema/introduction.mdx
@@ -147,8 +147,8 @@ All schema types support common properties like title, description, examples, de
 
 ### Code Generation
 Generate schemas from existing PHP code:
-- **PHP Classes** - Extract schemas from class properties and docblocks
-- **Closures** - Generate from function signatures and parameter types
+- **PHP Classes** - Extract schemas from class properties, constructor promotion, and docblocks (including array item types)
+- **Closures** - Generate from function signatures, parameter types, and docblock generics
 - **Backed Enums** - Create enum validation schemas
 - **JSON Import** - Convert existing JSON Schema definitions
 

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -9,11 +9,6 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="coverage"/>
-        </report>
-    </coverage>
     <source>
         <include>
             <directory suffix=".php">./src</directory>

--- a/src/Converters/ClassConverter.php
+++ b/src/Converters/ClassConverter.php
@@ -9,11 +9,14 @@ use ReflectionEnum;
 use ReflectionClass;
 use ReflectionProperty;
 use ReflectionNamedType;
+use ReflectionParameter;
 use Cortex\JsonSchema\Support\DocParser;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Contracts\Converter;
 use Cortex\JsonSchema\Enums\SchemaVersion;
 use Cortex\JsonSchema\Contracts\JsonSchema;
+use Cortex\JsonSchema\Support\NodeCollection;
+use Cortex\JsonSchema\Exceptions\UnknownTypeException;
 use Cortex\JsonSchema\Converters\Concerns\InteractsWithTypes;
 
 class ClassConverter implements Converter
@@ -32,6 +35,7 @@ class ClassConverter implements Converter
         protected object|string $class,
         protected bool $publicOnly = true,
         protected ?SchemaVersion $version = null,
+        protected bool $ignoreUnknownTypes = false,
     ) {
         $this->reflection = new ReflectionClass($this->class);
         $this->version = $version ?? SchemaVersion::default();
@@ -59,9 +63,26 @@ class ClassConverter implements Converter
             $this->publicOnly ? ReflectionProperty::IS_PUBLIC : null,
         );
 
+        // Constructor `@param` tags document promoted properties, which have no
+        // docblock of their own. Parse them once so we can resolve descriptions.
+        $promotedParams = $this->getConstructorParams();
+
         // Add the properties to the object schema
         foreach ($properties as $property) {
-            $objectSchema->properties(self::getSchemaFromReflectionProperty($property));
+            // Static properties are not part of the instance state, so skip them.
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            try {
+                $objectSchema->properties(self::getSchemaFromReflectionProperty($property, $promotedParams));
+            } catch (UnknownTypeException $unknownTypeException) {
+                if ($this->ignoreUnknownTypes) {
+                    continue;
+                }
+
+                throw $unknownTypeException;
+            }
         }
 
         return $objectSchema;
@@ -69,9 +90,12 @@ class ClassConverter implements Converter
 
     /**
      * Create a schema from a given type.
+     *
+     * @param \Cortex\JsonSchema\Support\NodeCollection<array-key, \Cortex\JsonSchema\Support\NodeData>|null $promotedParams
      */
     protected function getSchemaFromReflectionProperty(
         ReflectionProperty $reflectionProperty,
+        ?NodeCollection $promotedParams = null,
     ): JsonSchema {
         $type = $reflectionProperty->getType();
 
@@ -88,17 +112,36 @@ class ClassConverter implements Converter
 
         $variable = $docParser?->variable();
 
+        // Prefer the `@var` description on the property, falling back to the
+        // matching constructor `@param` description for promoted properties.
+        $description = $variable?->description;
+
+        if ($description === null && $reflectionProperty->isPromoted()) {
+            $description = $promotedParams?->get($reflectionProperty->getName())?->description;
+        }
+
         // Add the description to the schema if it exists
-        if ($variable?->description !== null) {
-            $jsonSchema->description($variable->description);
+        if ($description !== null) {
+            $jsonSchema->description($description);
         }
 
         if ($type === null || $type->allowsNull()) {
             $jsonSchema->nullable();
         }
 
-        if ($reflectionProperty->hasDefaultValue()) {
-            $defaultValue = $reflectionProperty->getDefaultValue();
+        // Promoted properties report their default value on the constructor
+        // parameter rather than on the property itself.
+        $promotedParameter = $reflectionProperty->isPromoted()
+            ? $this->getConstructorParameter($reflectionProperty->getName())
+            : null;
+
+        $hasDefault = $reflectionProperty->hasDefaultValue()
+            || $promotedParameter?->isDefaultValueAvailable() === true;
+
+        if ($hasDefault) {
+            $defaultValue = $reflectionProperty->hasDefaultValue()
+                ? $reflectionProperty->getDefaultValue()
+                : $promotedParameter?->getDefaultValue();
 
             // If the default value is a backed enum, use its value
             if ($defaultValue instanceof BackedEnum) {
@@ -138,5 +181,36 @@ class ClassConverter implements Converter
         return is_string($docComment)
             ? new DocParser($docComment)
             : null;
+    }
+
+    /**
+     * Parse the constructor's `@param` tags, used to describe promoted properties.
+     *
+     * @return \Cortex\JsonSchema\Support\NodeCollection<array-key, \Cortex\JsonSchema\Support\NodeData>|null
+     */
+    protected function getConstructorParams(): ?NodeCollection
+    {
+        $constructor = $this->reflection->getConstructor();
+        $docComment = $constructor?->getDocComment();
+
+        return is_string($docComment)
+            ? (new DocParser($docComment))->params()
+            : null;
+    }
+
+    /**
+     * Resolve the constructor parameter matching the given (promoted) property name.
+     */
+    protected function getConstructorParameter(string $name): ?ReflectionParameter
+    {
+        $constructor = $this->reflection->getConstructor();
+
+        foreach ($constructor?->getParameters() ?? [] as $parameter) {
+            if ($parameter->getName() === $name) {
+                return $parameter;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Converters/ClassConverter.php
+++ b/src/Converters/ClassConverter.php
@@ -113,33 +113,17 @@ class ClassConverter implements Converter
         }
 
         $variable = $docParser?->variable();
+        $description = $this->resolvePropertyDescription($variable, $reflectionProperty, $nodeCollection);
 
-        // Prefer the `@var` description on the property, falling back to the
-        // matching constructor `@param` description for promoted properties.
-        $description = $variable?->description;
-
-        if ($description === null && $reflectionProperty->isPromoted()) {
-            $description = $nodeCollection?->get($reflectionProperty->getName())?->description;
-        }
-
-        // Add the description to the schema if it exists
         if ($description !== null) {
             $jsonSchema->description($description);
         }
 
         if ($jsonSchema instanceof ArraySchema) {
-            $itemTypes = $variable instanceof NodeData ? $variable->itemTypes : [];
-
-            if ($itemTypes === [] && $reflectionProperty->isPromoted()) {
-                $promotedNode = $nodeCollection?->get($reflectionProperty->getName());
-                $itemTypes = $promotedNode instanceof NodeData ? $promotedNode->itemTypes : [];
-            }
-
-            $itemsSchema = $this->getItemsSchema($itemTypes);
-
-            if ($itemsSchema instanceof JsonSchema) {
-                $jsonSchema->items($itemsSchema);
-            }
+            $this->applyArrayItems(
+                $jsonSchema,
+                $this->resolvePropertyItemTypes($variable, $reflectionProperty, $nodeCollection),
+            );
         }
 
         if ($type === null || $type->allowsNull()) {
@@ -186,6 +170,50 @@ class ClassConverter implements Converter
         }
 
         return $jsonSchema;
+    }
+
+    /**
+     * Resolve a property description from `@var` or promoted constructor `@param` tags.
+     *
+     * @param \Cortex\JsonSchema\Support\NodeCollection<array-key, \Cortex\JsonSchema\Support\NodeData>|null $nodeCollection
+     */
+    protected function resolvePropertyDescription(
+        ?NodeData $nodeData,
+        ReflectionProperty $reflectionProperty,
+        ?NodeCollection $nodeCollection,
+    ): ?string {
+        if ($nodeData?->description !== null) {
+            return $nodeData->description;
+        }
+
+        if ($reflectionProperty->isPromoted()) {
+            return $nodeCollection?->get($reflectionProperty->getName())?->description;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve array element types from `@var` or promoted constructor `@param` tags.
+     *
+     * @param \Cortex\JsonSchema\Support\NodeCollection<array-key, \Cortex\JsonSchema\Support\NodeData>|null $nodeCollection
+     *
+     * @return array<array-key, string>
+     */
+    protected function resolvePropertyItemTypes(
+        ?NodeData $nodeData,
+        ReflectionProperty $reflectionProperty,
+        ?NodeCollection $nodeCollection,
+    ): array {
+        $itemTypes = $nodeData instanceof NodeData ? $nodeData->itemTypes : [];
+
+        if ($itemTypes !== [] || ! $reflectionProperty->isPromoted()) {
+            return $itemTypes;
+        }
+
+        $promotedNode = $nodeCollection?->get($reflectionProperty->getName());
+
+        return $promotedNode instanceof NodeData ? $promotedNode->itemTypes : [];
     }
 
     /**

--- a/src/Converters/ClassConverter.php
+++ b/src/Converters/ClassConverter.php
@@ -10,7 +10,9 @@ use ReflectionClass;
 use ReflectionProperty;
 use ReflectionNamedType;
 use ReflectionParameter;
+use Cortex\JsonSchema\Support\NodeData;
 use Cortex\JsonSchema\Support\DocParser;
+use Cortex\JsonSchema\Types\ArraySchema;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Contracts\Converter;
 use Cortex\JsonSchema\Enums\SchemaVersion;
@@ -91,11 +93,11 @@ class ClassConverter implements Converter
     /**
      * Create a schema from a given type.
      *
-     * @param \Cortex\JsonSchema\Support\NodeCollection<array-key, \Cortex\JsonSchema\Support\NodeData>|null $promotedParams
+     * @param \Cortex\JsonSchema\Support\NodeCollection<array-key, \Cortex\JsonSchema\Support\NodeData>|null $nodeCollection
      */
     protected function getSchemaFromReflectionProperty(
         ReflectionProperty $reflectionProperty,
-        ?NodeCollection $promotedParams = null,
+        ?NodeCollection $nodeCollection = null,
     ): JsonSchema {
         $type = $reflectionProperty->getType();
 
@@ -117,12 +119,27 @@ class ClassConverter implements Converter
         $description = $variable?->description;
 
         if ($description === null && $reflectionProperty->isPromoted()) {
-            $description = $promotedParams?->get($reflectionProperty->getName())?->description;
+            $description = $nodeCollection?->get($reflectionProperty->getName())?->description;
         }
 
         // Add the description to the schema if it exists
         if ($description !== null) {
             $jsonSchema->description($description);
+        }
+
+        if ($jsonSchema instanceof ArraySchema) {
+            $itemTypes = $variable instanceof NodeData ? $variable->itemTypes : [];
+
+            if ($itemTypes === [] && $reflectionProperty->isPromoted()) {
+                $promotedNode = $nodeCollection?->get($reflectionProperty->getName());
+                $itemTypes = $promotedNode instanceof NodeData ? $promotedNode->itemTypes : [];
+            }
+
+            $itemsSchema = $this->getItemsSchema($itemTypes);
+
+            if ($itemsSchema instanceof JsonSchema) {
+                $jsonSchema->items($itemsSchema);
+            }
         }
 
         if ($type === null || $type->allowsNull()) {

--- a/src/Converters/ClosureConverter.php
+++ b/src/Converters/ClosureConverter.php
@@ -10,7 +10,9 @@ use ReflectionEnum;
 use ReflectionFunction;
 use ReflectionNamedType;
 use ReflectionParameter;
+use Cortex\JsonSchema\Support\NodeData;
 use Cortex\JsonSchema\Support\DocParser;
+use Cortex\JsonSchema\Types\ArraySchema;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Contracts\Converter;
 use Cortex\JsonSchema\Enums\SchemaVersion;
@@ -94,6 +96,15 @@ class ClosureConverter implements Converter
         // Add the description to the schema if it exists
         if ($docParam?->description !== null) {
             $jsonSchema->description($docParam->description);
+        }
+
+        if ($jsonSchema instanceof ArraySchema) {
+            $itemTypes = $docParam instanceof NodeData ? $docParam->itemTypes : [];
+            $itemsSchema = $this->getItemsSchema($itemTypes);
+
+            if ($itemsSchema instanceof JsonSchema) {
+                $jsonSchema->items($itemsSchema);
+            }
         }
 
         if ($type === null || $type->allowsNull()) {

--- a/src/Converters/ClosureConverter.php
+++ b/src/Converters/ClosureConverter.php
@@ -99,12 +99,10 @@ class ClosureConverter implements Converter
         }
 
         if ($jsonSchema instanceof ArraySchema) {
-            $itemTypes = $docParam instanceof NodeData ? $docParam->itemTypes : [];
-            $itemsSchema = $this->getItemsSchema($itemTypes);
-
-            if ($itemsSchema instanceof JsonSchema) {
-                $jsonSchema->items($itemsSchema);
-            }
+            $this->applyArrayItems(
+                $jsonSchema,
+                $docParam instanceof NodeData ? $docParam->itemTypes : [],
+            );
         }
 
         if ($type === null || $type->allowsNull()) {

--- a/src/Converters/Concerns/InteractsWithTypes.php
+++ b/src/Converters/Concerns/InteractsWithTypes.php
@@ -57,4 +57,34 @@ trait InteractsWithTypes
 
         return SchemaType::fromScalar($typeName);
     }
+
+    /**
+     * Build an items schema from docblock element type strings.
+     *
+     * @param array<array-key, string> $itemTypes
+     */
+    protected function getItemsSchema(array $itemTypes): ?JsonSchema
+    {
+        if ($itemTypes === []) {
+            return null;
+        }
+
+        $schemaTypes = [];
+
+        foreach ($itemTypes as $itemType) {
+            $schemaType = SchemaType::tryFromScalar(ltrim($itemType, '\\'));
+
+            if (! $schemaType instanceof SchemaType) {
+                return null;
+            }
+
+            if (! in_array($schemaType, $schemaTypes, true)) {
+                $schemaTypes[] = $schemaType;
+            }
+        }
+
+        return count($schemaTypes) === 1
+            ? $schemaTypes[0]->instance(null, $this->version)
+            : new UnionSchema($schemaTypes, null, $this->version);
+    }
 }

--- a/src/Converters/Concerns/InteractsWithTypes.php
+++ b/src/Converters/Concerns/InteractsWithTypes.php
@@ -9,6 +9,7 @@ use ReflectionNamedType;
 use ReflectionUnionType;
 use ReflectionIntersectionType;
 use Cortex\JsonSchema\Enums\SchemaType;
+use Cortex\JsonSchema\Types\ArraySchema;
 use Cortex\JsonSchema\Types\UnionSchema;
 use Cortex\JsonSchema\Contracts\JsonSchema;
 use Cortex\JsonSchema\Exceptions\SchemaException;
@@ -56,6 +57,20 @@ trait InteractsWithTypes
         }
 
         return SchemaType::fromScalar($typeName);
+    }
+
+    /**
+     * Apply docblock-derived item types to an array schema when mappable.
+     *
+     * @param array<array-key, string> $itemTypes
+     */
+    protected function applyArrayItems(ArraySchema $arraySchema, array $itemTypes): void
+    {
+        $itemsSchema = $this->getItemsSchema($itemTypes);
+
+        if ($itemsSchema !== null) {
+            $arraySchema->items($itemsSchema);
+        }
     }
 
     /**

--- a/src/Enums/SchemaType.php
+++ b/src/Enums/SchemaType.php
@@ -56,4 +56,21 @@ enum SchemaType: string
             default => throw UnknownTypeException::forType($type),
         };
     }
+
+    /**
+     * Attempt to create a schema type from a given scalar type, returning null for unknown types.
+     */
+    public static function tryFromScalar(string $type): ?self
+    {
+        return match ($type) {
+            'int', 'integer' => self::Integer,
+            'float', 'double' => self::Number,
+            'string' => self::String,
+            'array' => self::Array,
+            'bool', 'boolean', 'true', 'false' => self::Boolean,
+            'object' => self::Object,
+            'null' => self::Null,
+            default => null,
+        };
+    }
 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -134,11 +134,13 @@ class Schema
         object|string $class,
         bool $publicOnly = true,
         ?SchemaVersion $schemaVersion = null,
+        bool $ignoreUnknownTypes = false,
     ): ObjectSchema {
         $classConverter = new ClassConverter(
             $class,
             $publicOnly,
             $schemaVersion ?? self::getDefaultVersion(),
+            $ignoreUnknownTypes,
         );
 
         return $classConverter->convert();
@@ -179,6 +181,7 @@ class Schema
                 $value,
                 true,
                 $schemaVersion,
+                $ignoreUnknownTypes,
             ),
             // @phpstan-ignore argument.type
             is_array($value) || (is_string($value) && json_validate($value)) => self::fromJson($value, $schemaVersion),

--- a/src/Support/DocParser.php
+++ b/src/Support/DocParser.php
@@ -47,11 +47,10 @@ class DocParser
     public function params(): NodeCollection
     {
         $nodes = array_map(
-            static fn(ParamTagValueNode|TypelessParamTagValueNode $param): NodeData => new NodeData(
-                name: ltrim($param->parameterName, '$'),
-                description: $param->description === '' ? null : $param->description,
-                types: self::mapValueNodeToTypes($param),
-                itemTypes: self::mapValueNodeToItemTypes($param),
+            static fn(ParamTagValueNode|TypelessParamTagValueNode $param): NodeData => self::createNodeData(
+                ltrim($param->parameterName, '$'),
+                $param->description,
+                $param,
             ),
             array_merge(
                 $this->parse()->getParamTagValues(),
@@ -68,11 +67,10 @@ class DocParser
     public function variable(): ?NodeData
     {
         $vars = array_map(
-            static fn(VarTagValueNode $varTagValueNode): NodeData => new NodeData(
-                name: ltrim($varTagValueNode->variableName, '$'),
-                description: $varTagValueNode->description === '' ? null : $varTagValueNode->description,
-                types: self::mapValueNodeToTypes($varTagValueNode),
-                itemTypes: self::mapValueNodeToItemTypes($varTagValueNode),
+            static fn(VarTagValueNode $varTagValueNode): NodeData => self::createNodeData(
+                ltrim($varTagValueNode->variableName, '$'),
+                $varTagValueNode->description,
+                $varTagValueNode,
             ),
             $this->parse()->getVarTagValues(),
         );
@@ -87,6 +85,19 @@ class DocParser
     public function isDeprecated(): bool
     {
         return $this->parse()->getTagsByName('@deprecated') !== [];
+    }
+
+    protected static function createNodeData(
+        string $name,
+        string $description,
+        ParamTagValueNode|TypelessParamTagValueNode|VarTagValueNode $tag,
+    ): NodeData {
+        return new NodeData(
+            name: $name,
+            description: $description === '' ? null : $description,
+            types: self::mapValueNodeToTypes($tag),
+            itemTypes: self::mapValueNodeToItemTypes($tag),
+        );
     }
 
     /**

--- a/src/Support/DocParser.php
+++ b/src/Support/DocParser.php
@@ -11,8 +11,10 @@ use PHPStan\PhpDocParser\Parser\TypeParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
@@ -49,6 +51,7 @@ class DocParser
                 name: ltrim($param->parameterName, '$'),
                 description: $param->description === '' ? null : $param->description,
                 types: self::mapValueNodeToTypes($param),
+                itemTypes: self::mapValueNodeToItemTypes($param),
             ),
             array_merge(
                 $this->parse()->getParamTagValues(),
@@ -69,6 +72,7 @@ class DocParser
                 name: ltrim($varTagValueNode->variableName, '$'),
                 description: $varTagValueNode->description === '' ? null : $varTagValueNode->description,
                 types: self::mapValueNodeToTypes($varTagValueNode),
+                itemTypes: self::mapValueNodeToItemTypes($varTagValueNode),
             ),
             $this->parse()->getVarTagValues(),
         );
@@ -107,6 +111,79 @@ class DocParser
                 'null',
             ],
             default => [(string) $param->type],
+        };
+    }
+
+    /**
+     * Map the value node to its array element types.
+     *
+     * @return array<array-key, string>
+     */
+    protected static function mapValueNodeToItemTypes(
+        ParamTagValueNode|TypelessParamTagValueNode|VarTagValueNode $param,
+    ): array {
+        if ($param instanceof TypelessParamTagValueNode) {
+            return [];
+        }
+
+        return self::extractItemTypesFromTypeNode($param->type);
+    }
+
+    /**
+     * Extract array element types from a type node.
+     *
+     * @return array<array-key, string>
+     */
+    protected static function extractItemTypesFromTypeNode(TypeNode $typeNode): array
+    {
+        return match (true) {
+            $typeNode instanceof ArrayTypeNode => self::typeNodeToStrings($typeNode->type),
+            $typeNode instanceof GenericTypeNode => self::extractGenericArrayItemTypes($typeNode),
+            default => [],
+        };
+    }
+
+    /**
+     * Extract element types from generic array/list types.
+     *
+     * @return array<array-key, string>
+     */
+    protected static function extractGenericArrayItemTypes(GenericTypeNode $genericTypeNode): array
+    {
+        $baseName = strtolower($genericTypeNode->type->name);
+
+        if (! in_array($baseName, ['array', 'list', 'iterable', 'non-empty-array', 'non-empty-list'], true)) {
+            return [];
+        }
+
+        if ($genericTypeNode->genericTypes === []) {
+            return [];
+        }
+
+        $valueType = $genericTypeNode->genericTypes[array_key_last($genericTypeNode->genericTypes)];
+
+        return self::typeNodeToStrings($valueType);
+    }
+
+    /**
+     * Resolve a type node to its constituent type strings.
+     *
+     * @return array<array-key, string>
+     */
+    protected static function typeNodeToStrings(TypeNode $typeNode): array
+    {
+        return match (true) {
+            $typeNode instanceof UnionTypeNode => array_merge(
+                ...array_map(
+                    self::typeNodeToStrings(...),
+                    $typeNode->types,
+                ),
+            ),
+            $typeNode instanceof NullableTypeNode => [
+                ...self::typeNodeToStrings($typeNode->type),
+                'null',
+            ],
+            default => [(string) $typeNode],
         };
     }
 

--- a/src/Support/NodeData.php
+++ b/src/Support/NodeData.php
@@ -8,10 +8,12 @@ class NodeData
 {
     /**
      * @param array<array-key, string> $types
+     * @param array<array-key, string> $itemTypes
      */
     public function __construct(
         public string $name,
         public ?string $description = null,
         public array $types = [],
+        public array $itemTypes = [],
     ) {}
 }

--- a/tests/Unit/Converters/ClassConverterTest.php
+++ b/tests/Unit/Converters/ClassConverterTest.php
@@ -584,3 +584,88 @@ it('skips unknown property types when ignoreUnknownTypes is enabled', function (
     expect($array['properties'])->toHaveKey('name');
     expect($array['properties'])->not->toHaveKey('createdAt');
 });
+
+it('can create array items schema from @var string[] docblock', function (): void {
+    $objectSchema = (new ClassConverter(new class () {
+        /**
+         * @var string[] The user's tags
+         */
+        public array $tags;
+    }))->convert();
+
+    expect($objectSchema->toArray())->toBe([
+        'type' => 'object',
+        '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+        'properties' => [
+            'tags' => [
+                'type' => 'array',
+                'description' => "The user's tags",
+                'items' => [
+                    'type' => 'string',
+                    '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                ],
+            ],
+        ],
+        'required' => [
+            'tags',
+        ],
+    ]);
+});
+
+it('can create array items schema from promoted @param int[] docblock', function (): void {
+    $class = new class ([]) {
+        /**
+         * @param int[] $ids The user identifiers
+         */
+        public function __construct(
+            public array $ids,
+        ) {}
+    };
+
+    $objectSchema = (new ClassConverter($class))->convert();
+
+    expect($objectSchema->toArray()['properties']['ids'])->toBe([
+        'type' => 'array',
+        'description' => 'The user identifiers',
+        'items' => [
+            'type' => 'integer',
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+        ],
+    ]);
+});
+
+it('can create array items schema for nullable array properties', function (): void {
+    $objectSchema = (new ClassConverter(new class () {
+        /**
+         * @var string[] Optional tags
+         */
+        public ?array $tags = null;
+    }))->convert();
+
+    expect($objectSchema->toArray()['properties']['tags'])->toBe([
+        'type' => [
+            'array',
+            'null',
+        ],
+        'description' => 'Optional tags',
+        'default' => null,
+        'items' => [
+            'type' => 'string',
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+        ],
+    ]);
+});
+
+it('leaves array properties without items when element type is unmappable', function (): void {
+    $objectSchema = (new ClassConverter(new class () {
+        /**
+         * @var DateTime[] Scheduled dates
+         */
+        public array $dates;
+    }))->convert();
+
+    expect($objectSchema->toArray()['properties']['dates'])->toBe([
+        'type' => 'array',
+        'description' => 'Scheduled dates',
+    ]);
+});

--- a/tests/Unit/Converters/ClassConverterTest.php
+++ b/tests/Unit/Converters/ClassConverterTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Cortex\JsonSchema\Tests\Unit\Converters;
 
+use DateTime;
 use Cortex\JsonSchema\Types\ObjectSchema;
 use Cortex\JsonSchema\Converters\ClassConverter;
+use Cortex\JsonSchema\Exceptions\UnknownTypeException;
 
 covers(ClassConverter::class);
 
@@ -116,11 +118,11 @@ it('can create a schema from a class with constructor property promotion', funct
             ],
             'age' => [
                 'type' => 'integer',
+                'default' => 20,
             ],
         ],
         'required' => [
             'name',
-            'age',
         ],
     ]);
 });
@@ -478,4 +480,107 @@ it('can create a schema from a class with inheritance and traits', function (): 
     expect($array['properties'])->toHaveKey('deleted_at');
     expect($array['properties'])->toHaveKey('name');
     expect($array['properties'])->toHaveKey('email');
+});
+
+it('ignores static properties', function (): void {
+    $objectSchema = (new ClassConverter(new class () {
+        public string $name = 'John';
+
+        public static string $table = 'users';
+
+        public static int $count = 0;
+    }))->convert();
+
+    expect($objectSchema)->toBeInstanceOf(ObjectSchema::class);
+
+    $array = $objectSchema->toArray();
+
+    expect($array['properties'])->toHaveKey('name');
+    expect($array['properties'])->not->toHaveKey('table');
+    expect($array['properties'])->not->toHaveKey('count');
+});
+
+it('uses constructor @param tags to describe promoted properties', function (): void {
+    /**
+     * A user data transfer object
+     */
+    $class = new class ('John Doe') {
+        /**
+         * @param string $name The name of the user
+         * @param int $age The age of the user in years
+         */
+        public function __construct(
+            public string $name,
+            public int $age = 20,
+        ) {}
+    };
+
+    $objectSchema = (new ClassConverter($class))->convert();
+
+    expect($objectSchema)->toBeInstanceOf(ObjectSchema::class);
+    expect($objectSchema->toArray())->toBe([
+        'type' => 'object',
+        '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+        'description' => 'A user data transfer object',
+        'properties' => [
+            'name' => [
+                'type' => 'string',
+                'description' => 'The name of the user',
+            ],
+            'age' => [
+                'type' => 'integer',
+                'description' => 'The age of the user in years',
+                'default' => 20,
+            ],
+        ],
+        'required' => [
+            'name',
+        ],
+    ]);
+});
+
+it('prefers a property @var description over the constructor @param description', function (): void {
+    $class = new class ('John Doe') {
+        /**
+         * @param string $name This should be ignored in favour of the @var tag
+         */
+        public function __construct(
+            /**
+             * @var string The canonical name description
+             */
+            public string $name,
+        ) {}
+    };
+
+    $objectSchema = (new ClassConverter($class))->convert();
+
+    $array = $objectSchema->toArray();
+
+    expect($array['properties']['name']['description'])->toBe('The canonical name description');
+});
+
+it('throws for unknown property types by default', function (): void {
+    $class = new class () {
+        public DateTime $createdAt;
+    };
+
+    expect(fn(): ObjectSchema => (new ClassConverter($class))->convert())
+        ->toThrow(UnknownTypeException::class);
+});
+
+it('skips unknown property types when ignoreUnknownTypes is enabled', function (): void {
+    $class = new class () {
+        public string $name;
+
+        public DateTime $createdAt;
+    };
+
+    $objectSchema = (new ClassConverter($class, ignoreUnknownTypes: true))->convert();
+
+    expect($objectSchema)->toBeInstanceOf(ObjectSchema::class);
+
+    $array = $objectSchema->toArray();
+
+    expect($array['properties'])->toHaveKey('name');
+    expect($array['properties'])->not->toHaveKey('createdAt');
 });

--- a/tests/Unit/Converters/ClosureConverterTest.php
+++ b/tests/Unit/Converters/ClosureConverterTest.php
@@ -475,3 +475,20 @@ it('can create a schema from a deprecated closure without description', function
         ],
     ]);
 });
+
+it('can create array items schema from @param string[] docblock', function (): void {
+    /**
+     * @param string[] $tags The user's tags
+     */
+    $closure = function (array $tags): void {};
+    $objectSchema = (new ClosureConverter($closure))->convert();
+
+    expect($objectSchema->toArray()['properties']['tags'])->toBe([
+        'type' => 'array',
+        'description' => "The user's tags",
+        'items' => [
+            'type' => 'string',
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+        ],
+    ]);
+});

--- a/tests/Unit/Enums/SchemaTypeTest.php
+++ b/tests/Unit/Enums/SchemaTypeTest.php
@@ -31,6 +31,26 @@ it('throws exception for unknown scalar type', function (): void {
         ->toThrow(UnknownTypeException::class, 'Unknown type: unknown');
 });
 
+it('can resolve scalar types with tryFromScalar', function (string $input, SchemaType $schemaType): void {
+    expect(SchemaType::tryFromScalar($input))->toBe($schemaType);
+})->with([
+    'int' => ['int', SchemaType::Integer],
+    'integer' => ['integer', SchemaType::Integer],
+    'float' => ['float', SchemaType::Number],
+    'double' => ['double', SchemaType::Number],
+    'string' => ['string', SchemaType::String],
+    'bool' => ['bool', SchemaType::Boolean],
+    'boolean' => ['boolean', SchemaType::Boolean],
+    'true' => ['true', SchemaType::Boolean],
+    'false' => ['false', SchemaType::Boolean],
+    'null' => ['null', SchemaType::Null],
+]);
+
+it('returns null from tryFromScalar for unknown types', function (): void {
+    expect(SchemaType::tryFromScalar('DateTime'))->toBeNull();
+    expect(SchemaType::tryFromScalar('mixed'))->toBeNull();
+});
+
 it('can create schema instance', function (SchemaType $schemaType, string $expectedClass): void {
     expect($schemaType->instance())->toBeInstanceOf($expectedClass);
 })->with([

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -123,11 +123,11 @@ it('can create a schema from a class', function (): void {
             ],
             'age' => [
                 'type' => 'integer',
+                'default' => 20,
             ],
         ],
         'required' => [
             'name',
-            'age',
         ],
     ]);
 

--- a/tests/Unit/Support/DocParserTest.php
+++ b/tests/Unit/Support/DocParserTest.php
@@ -407,26 +407,24 @@ it('can detect multiple deprecated tags', function (): void {
     expect($parser->isDeprecated())->toBeTrue();
 });
 
-it('can parse array item types from docblocks', function (): void {
-    $cases = [
-        'string[]' => ['/** @var string[] $tags */', ['string']],
-        'array<string>' => ['/** @var array<string> $tags */', ['string']],
-        'array<string, int>' => ['/** @var array<string, int> $scores */', ['int']],
-        'list<bool>' => ['/** @var list<bool> $flags */', ['bool']],
-        'array<int|string>' => ['/** @var array<int|string> $values */', ['int', 'string']],
-        '(int|string)[]' => ['/** @var (int|string)[] $values */', ['int', 'string']],
-        'DateTime[]' => ['/** @var DateTime[] $dates */', ['DateTime']],
-        'param string[]' => ['/** @param string[] $tags The tags */', ['string']],
-    ];
+it('can parse array item types from docblocks', function (string $docblock, array $expectedItemTypes, string $source): void {
+    $parser = new DocParser($docblock);
 
-    foreach ($cases as $label => [$docblock, $expectedItemTypes]) {
-        $parser = new DocParser($docblock);
+    $node = $source === 'params'
+        ? $parser->params()->get('tags')
+        : $parser->variable();
 
-        $node = str_contains($docblock, '@param') ? $parser->params()->get('tags') : $parser->variable();
-
-        expect($node?->itemTypes)->toBe($expectedItemTypes, 'Failed for case: ' . $label);
-    }
-});
+    expect($node?->itemTypes)->toBe($expectedItemTypes);
+})->with([
+    'string[]' => ['/** @var string[] $tags */', ['string'], 'variable'],
+    'array<string>' => ['/** @var array<string> $tags */', ['string'], 'variable'],
+    'array<string, int>' => ['/** @var array<string, int> $scores */', ['int'], 'variable'],
+    'list<bool>' => ['/** @var list<bool> $flags */', ['bool'], 'variable'],
+    'array<int|string>' => ['/** @var array<int|string> $values */', ['int', 'string'], 'variable'],
+    '(int|string)[]' => ['/** @var (int|string)[] $values */', ['int', 'string'], 'variable'],
+    'DateTime[]' => ['/** @var DateTime[] $dates */', ['DateTime'], 'variable'],
+    'param string[]' => ['/** @param string[] $tags The tags */', ['string'], 'params'],
+]);
 
 it('returns empty item types for non-array docblock types', function (): void {
     $docblock = '/** @var string $name The name */';

--- a/tests/Unit/Support/DocParserTest.php
+++ b/tests/Unit/Support/DocParserTest.php
@@ -407,15 +407,18 @@ it('can detect multiple deprecated tags', function (): void {
     expect($parser->isDeprecated())->toBeTrue();
 });
 
-it('can parse array item types from docblocks', function (string $docblock, array $expectedItemTypes, string $source): void {
-    $parser = new DocParser($docblock);
+it(
+    'can parse array item types from docblocks',
+    function (string $docblock, array $expectedItemTypes, string $source): void {
+        $parser = new DocParser($docblock);
 
-    $node = $source === 'params'
-        ? $parser->params()->get('tags')
-        : $parser->variable();
+        $node = $source === 'params'
+            ? $parser->params()->get('tags')
+            : $parser->variable();
 
-    expect($node?->itemTypes)->toBe($expectedItemTypes);
-})->with([
+        expect($node?->itemTypes)->toBe($expectedItemTypes);
+    },
+)->with([
     'string[]' => ['/** @var string[] $tags */', ['string'], 'variable'],
     'array<string>' => ['/** @var array<string> $tags */', ['string'], 'variable'],
     'array<string, int>' => ['/** @var array<string, int> $scores */', ['int'], 'variable'],

--- a/tests/Unit/Support/DocParserTest.php
+++ b/tests/Unit/Support/DocParserTest.php
@@ -407,6 +407,34 @@ it('can detect multiple deprecated tags', function (): void {
     expect($parser->isDeprecated())->toBeTrue();
 });
 
+it('can parse array item types from docblocks', function (): void {
+    $cases = [
+        'string[]' => ['/** @var string[] $tags */', ['string']],
+        'array<string>' => ['/** @var array<string> $tags */', ['string']],
+        'array<string, int>' => ['/** @var array<string, int> $scores */', ['int']],
+        'list<bool>' => ['/** @var list<bool> $flags */', ['bool']],
+        'array<int|string>' => ['/** @var array<int|string> $values */', ['int', 'string']],
+        '(int|string)[]' => ['/** @var (int|string)[] $values */', ['int', 'string']],
+        'DateTime[]' => ['/** @var DateTime[] $dates */', ['DateTime']],
+        'param string[]' => ['/** @param string[] $tags The tags */', ['string']],
+    ];
+
+    foreach ($cases as $label => [$docblock, $expectedItemTypes]) {
+        $parser = new DocParser($docblock);
+
+        $node = str_contains($docblock, '@param') ? $parser->params()->get('tags') : $parser->variable();
+
+        expect($node?->itemTypes)->toBe($expectedItemTypes, 'Failed for case: ' . $label);
+    }
+});
+
+it('returns empty item types for non-array docblock types', function (): void {
+    $docblock = '/** @var string $name The name */';
+    $parser = new DocParser($docblock);
+
+    expect($parser->variable()?->itemTypes)->toBe([]);
+});
+
 it('handles deprecation with complex docblock', function (): void {
     $docblock = <<<'EOD'
         /**


### PR DESCRIPTION
This pull request enhances the handling of array types and promoted properties in docblock parsing and JSON Schema generation. It introduces support for extracting array element types from docblocks, improves the resolution of descriptions and default values for promoted properties, and adds an option to ignore unknown types. The changes also include utility improvements for schema type resolution and extend the test coverage to verify these behaviors.

**Docblock Parsing and Array Type Extraction:**
- Extended the `DocParser` to extract element types from `@var` and `@param` docblock tags, including support for generic array types (e.g., `array<int>`, `list<string>`), and propagate these types into the schema via a new `itemTypes` property on `NodeData`. [[1]](diffhunk://#diff-0f7d098b080489cb42a19d84ddd8ebc9d93ace3a8e62060c610f4ff9beab69ebR90-R102) [[2]](diffhunk://#diff-0f7d098b080489cb42a19d84ddd8ebc9d93ace3a8e62060c610f4ff9beab69ebR128-R200) [[3]](diffhunk://#diff-47a00d82c108c8e8ec4e13d81d429a6b58f8b1d6a06a8562a577e10424288e95R11-R17)

**Promoted Property and Default Value Handling:**
- Improved the `ClassConverter` to resolve property descriptions and array element types for promoted properties using constructor `@param` tags, and to correctly determine default values for promoted properties. [[1]](diffhunk://#diff-4a563f5ab5dc480f21e40c9267fa85959bfca2c1d479eff738a10bdc401ee788R68-R100) [[2]](diffhunk://#diff-4a563f5ab5dc480f21e40c9267fa85959bfca2c1d479eff738a10bdc401ee788R116-R145) [[3]](diffhunk://#diff-4a563f5ab5dc480f21e40c9267fa85959bfca2c1d479eff738a10bdc401ee788R175-R218) [[4]](diffhunk://#diff-4a563f5ab5dc480f21e40c9267fa85959bfca2c1d479eff738a10bdc401ee788R230-R260)

**Array Schema Generation:**
- Added logic in `InteractsWithTypes` to apply docblock-derived item types to array schemas, including union types, and to build the appropriate schema representation for array elements.

**Type Resolution and Robustness:**
- Introduced `SchemaType::tryFromScalar` to safely resolve scalar types without throwing exceptions for unknown types, enabling more robust schema generation when encountering unrecognized types.

**API and Test Enhancements:**
- Updated the `Schema::fromClass` and `Schema::from` methods to accept an `ignoreUnknownTypes` flag, allowing callers to skip properties with unknown types. Expanded test coverage in `ClassConverterTest` to verify new behaviors, including default value handling for promoted properties. [[1]](diffhunk://#diff-aba1adae571d18ad5f7c6db19cfd8f15eb41daae1806924278c9a119f7c8b6daR137-R143) [[2]](diffhunk://#diff-aba1adae571d18ad5f7c6db19cfd8f15eb41daae1806924278c9a119f7c8b6daR184) [[3]](diffhunk://#diff-fd5f8f006f398f2ed02a3b9ce7cc814d2e505a260adc90ed340e70fb367ddd9bR121-L123)

Other minor changes include dependency imports and the removal of the coverage report configuration from `phpunit.dist.xml`.